### PR TITLE
Feat: 变量更新接口改为只支持传当前实例添加的变量

### DIFF
--- a/cmds/tool/demo.go
+++ b/cmds/tool/demo.go
@@ -160,9 +160,9 @@ func (p *InitDemo) Execute(args []string) error {
 	fmt.Printf("key_id = %s\n", key.Id)
 
 	// 创建变量
-	variables := make([]forms.Variables, 0)
+	variables := make([]forms.Variable, 0)
 	for _, v := range data.Organization.Variables {
-		variables = append(variables, forms.Variables{
+		variables = append(variables, forms.Variable{
 			Scope:       consts.ScopeOrg,
 			Name:        v.Name,
 			Description: v.Description,

--- a/portal/apps/variables.go
+++ b/portal/apps/variables.go
@@ -108,6 +108,11 @@ func updateObjectVars(c *ctx.ServiceContext, tx *db.Session, form *forms.UpdateO
 		case consts.ScopeEnv:
 			modelVar.OrgId = orgId
 			modelVar.ProjectId = projectId
+			if env, er := services.GetEnvById(tx, objectId); er != nil {
+				return nil, er
+			} else {
+				modelVar.TplId = env.TplId
+			}
 			modelVar.EnvId = objectId
 		}
 		vars = append(vars, modelVar)

--- a/portal/apps/variables.go
+++ b/portal/apps/variables.go
@@ -6,6 +6,7 @@ import (
 	"cloudiac/portal/consts"
 	"cloudiac/portal/consts/e"
 	"cloudiac/portal/libs/ctx"
+	"cloudiac/portal/libs/db"
 	"cloudiac/portal/models"
 	"cloudiac/portal/models/forms"
 	"cloudiac/portal/services"
@@ -34,6 +35,90 @@ func BatchUpdate(c *ctx.ServiceContext, form *forms.BatchUpdateVariableForm) (in
 	}
 
 	return nil, nil
+}
+
+func UpdateObjectVars(c *ctx.ServiceContext, form *forms.UpdateObjectVarsForm) (interface{}, e.Error) {
+	var (
+		result interface{}
+		err    error
+	)
+	err = c.DB().Transaction(func(tx *db.Session) error {
+		result, err = updateObjectVars(c, tx, form)
+		return err
+	})
+	if err != nil {
+		return nil, e.AutoNew(err, e.DBError)
+	}
+	return result, nil
+}
+
+func updateObjectVars(c *ctx.ServiceContext, tx *db.Session, form *forms.UpdateObjectVarsForm) (interface{}, e.Error) {
+	var (
+		orgId     = c.OrgId
+		projectId = c.ProjectId
+		scope     = form.Scope
+		objectId  = form.ObjectId
+	)
+
+	for _, v := range form.Variables {
+		if v.Scope != form.Scope {
+			return nil, e.New(e.VariableScopeConflict)
+		}
+		if v.Name == "" {
+			return nil, e.New(e.EmptyVarName)
+		}
+	}
+
+	switch scope {
+	case consts.ScopeOrg:
+		if objectId != orgId {
+			return nil, e.New(e.BadOrgId)
+		}
+	case consts.ScopeProject:
+		if objectId != projectId {
+			return nil, e.New(e.BadProjectId)
+		}
+	}
+
+	vars := make([]models.Variable, 0, len(form.Variables))
+	for _, v := range form.Variables {
+		modelVar := models.Variable{
+			VariableBody: models.VariableBody{
+				Scope:       v.Scope,
+				Type:        v.Type,
+				Name:        v.Name,
+				Value:       v.Value,
+				Sensitive:   v.Sensitive,
+				Description: v.Description,
+				Options:     v.Options,
+			},
+		}
+		modelVar.Id = v.Id
+
+		switch scope {
+		case consts.ScopeOrg:
+			modelVar.OrgId = orgId
+		case consts.ScopeProject:
+			modelVar.OrgId = orgId
+			modelVar.ProjectId = projectId
+		case consts.ScopeTemplate:
+			modelVar.OrgId = orgId
+			modelVar.TplId = objectId
+		case consts.ScopeEnv:
+			modelVar.OrgId = orgId
+			modelVar.ProjectId = projectId
+			modelVar.EnvId = objectId
+		}
+		vars = append(vars, modelVar)
+	}
+
+	tx = services.QueryWithOrgId(tx, c.OrgId)
+	retVars, err := services.UpdateObjectVars(tx, scope, objectId, vars)
+	if err != nil {
+		c.Logger().Warnf("update object %s(%s) vars error: %v", form.Scope, form.ObjectId, err)
+		return nil, e.AutoNew(err, e.InternalError)
+	}
+	return services.VarsDesensitization(retVars), nil
 }
 
 type newVariable []VariableResp

--- a/portal/apps/variables.go
+++ b/portal/apps/variables.go
@@ -11,6 +11,7 @@ import (
 	"cloudiac/portal/models/forms"
 	"cloudiac/portal/services"
 	"fmt"
+	"net/http"
 	"sort"
 )
 
@@ -62,10 +63,10 @@ func updateObjectVars(c *ctx.ServiceContext, tx *db.Session, form *forms.UpdateO
 
 	for _, v := range form.Variables {
 		if v.Scope != form.Scope {
-			return nil, e.New(e.VariableScopeConflict)
+			return nil, e.New(e.VariableScopeConflict, http.StatusBadRequest)
 		}
 		if v.Name == "" {
-			return nil, e.New(e.EmptyVarName)
+			return nil, e.New(e.EmptyVarName, http.StatusBadRequest)
 		}
 	}
 

--- a/portal/consts/e/e.go
+++ b/portal/consts/e/e.go
@@ -152,13 +152,18 @@ func GetErr(err error) (*MyError, bool) {
 	return er, ok
 }
 
-func AutoNew(err error, code int) Error {
+func AutoNew(err error, code int, status ...int) Error {
 	// 如果 err 是 Error 类型则直接返回
 	if er, ok := GetErr(err); ok {
 		return er
 	}
+
 	// 否则生成一个 code 对应的 Error
-	return New(code, err)
+	if len(status) > 0 {
+		return New(code, err, status[0])
+	} else {
+		return New(code, err)
+	}
 }
 
 const defaultLang = "zh-cn"

--- a/portal/consts/e/errors.go
+++ b/portal/consts/e/errors.go
@@ -20,14 +20,14 @@ const (
 	NotImplement            = 10020
 	IOError                 = 10030 // 文件 io 出错
 	TooManyRetries          = 10040
+	EncryptError            = 10050
+	DecryptError            = 10051
 
 	//// 解析错误 101
-
 	JSONParseError = 10100
 	HCLParseError  = 10101
 
 	//// db 错误 102
-
 	DBError           = 10200 // db 操作出错
 	DBAttrValidateErr = 10201
 	ColValidateError  = 10202
@@ -40,6 +40,10 @@ const (
 	TagTooMuch        = 10215
 
 	//// 校验错误 103
+	BadOrgId               = 10310
+	BadProjectId           = 10311
+	BadTemplateId          = 10312
+	BadEnvId               = 10314
 	BadParam               = 10340 // 参数错误(参数值不对)
 	BadRequest             = 10341 // 请求错误(请求缺少必要参数)
 	InvalidPipeline        = 10350
@@ -106,6 +110,9 @@ const (
 	//// variable 305
 	VariableAlreadyExists  = 30510
 	VariableAliasDuplicate = 30511
+	VariableScopeConflict  = 30512
+	InvalidVarName         = 30513
+	EmptyVarName           = 30514
 
 	//// token 306
 	TokenAlreadyExists  = 30610
@@ -197,6 +204,18 @@ var errorMsgs = map[int]map[string]string{
 	DBAttrValidateErr: {
 		"zh-cn": "字段验证错误",
 	},
+	BadOrgId: {
+		"zh-cn": "组织 ID 错误",
+	},
+	BadProjectId: {
+		"zh-cn": "项目 ID 错误",
+	},
+	BadTemplateId: {
+		"zh-cn": "模板 ID 错误",
+	},
+	BadEnvId: {
+		"zh-cn": "环境 ID 错误",
+	},
 	BadParam: {
 		"zh-cn": "无效参数",
 	},
@@ -232,6 +251,12 @@ var errorMsgs = map[int]map[string]string{
 	},
 	TooManyRetries: {
 		"zh-cn": "达到最大重试次数",
+	},
+	EncryptError: {
+		"zh-cn": "数据加密错误",
+	},
+	DecryptError: {
+		"zh-cn": "数据解密错误",
 	},
 	MailServerError: {
 		"zh-cn": "邮件服务错误",
@@ -351,7 +376,15 @@ var errorMsgs = map[int]map[string]string{
 	VariableAliasDuplicate: {
 		"zh-cn": "变量别名重复",
 	},
-
+	VariableScopeConflict: {
+		"zh-cn": "变量作用域冲突",
+	},
+	InvalidVarName: {
+		"zh-cn": "无效变量名",
+	},
+	EmptyVarName: {
+		"zh-cn": "变量名不可为空",
+	},
 	ProjectUserAlreadyExists: {
 		"zh-cn": "项目用户已经存在",
 	},

--- a/portal/models/forms/env.go
+++ b/portal/models/forms/env.go
@@ -28,7 +28,7 @@ type CreateEnvForm struct {
 	Revision        string `form:"revision" json:"revision" binding:""`                             // 分支/标签
 	Timeout         int    `form:"timeout" json:"timeout" binding:""`                               // 部署超时时间（单位：秒）
 
-	Variables []Variables `form:"variables" json:"variables" binding:""` // 自定义变量列表，该变量列表会覆盖现有的变量
+	Variables []Variable `form:"variables" json:"variables" binding:""` // 自定义变量列表，该变量列表会覆盖现有的变量
 
 	TfVarsFile   string    `form:"tfVarsFile" json:"tfVarsFile" binding:""`     // Terraform tfvars 变量文件路径
 	PlayVarsFile string    `form:"playVarsFile" json:"playVarsFile" binding:""` // Ansible playbook 变量文件路径
@@ -95,8 +95,7 @@ type DeployEnvForm struct {
 	RetryDelay  int  `form:"retryDelay" json:"retryDelay" binding:""`   // 重试时间间隔
 	RetryAble   bool `form:"retryAble" json:"retryAble" binding:""`     // 是否允许任务进行重试
 
-	Variables         []Variables `form:"variables" json:"variables" binding:""`       // 自定义变量列表，该变量列表会覆盖现有的变量
-	DeleteVariablesId []string    `json:"deleteVariablesId" form:"deleteVariablesId" ` //删除的变量id
+	Variables []Variable `form:"variables" json:"variables" binding:""` // 自定义变量列表，该变量列表会覆盖现有的变量
 
 	TfVarsFile   string    `form:"tfVarsFile" json:"tfVarsFile" binding:""`     // Terraform tfvars 变量文件路径
 	PlayVarsFile string    `form:"playVarsFile" json:"playVarsFile" binding:""` // Ansible playbook 变量文件路径

--- a/portal/models/forms/template.go
+++ b/portal/models/forms/template.go
@@ -26,7 +26,7 @@ type CreateTemplateForm struct {
 	Playbook          string      `json:"playbook" form:"playbook"`
 	PlayVarsFile      string      `json:"playVarsFile" form:"playVarsFile"`
 	TfVarsFile        string      `form:"tfVarsFile" json:"tfVarsFile"`
-	Variables         []Variables `json:"variables" form:"variables" `
+	Variables         []Variable `json:"variables" form:"variables" `
 	DeleteVariablesId []string    `json:"deleteVariablesId" form:"deleteVariablesId" ` //变量id
 	ProjectId         []models.Id `form:"projectId" json:"projectId"`                  // 项目ID
 	TfVersion         string      `form:"tfVersion" json:"tfVersion"`                  // 模版使用terraform版本号
@@ -52,7 +52,7 @@ type UpdateTemplateForm struct {
 	Playbook          string      `json:"playbook" form:"playbook"`
 	PlayVarsFile      string      `json:"playVarsFile" form:"playVarsFile"`
 	TfVarsFile        string      `form:"tfVarsFile" json:"tfVarsFile"`
-	Variables         []Variables `json:"variables" form:"variables" `
+	Variables         []Variable `json:"variables" form:"variables" `
 	DeleteVariablesId []string    `json:"deleteVariablesId" form:"deleteVariablesId" ` //变量id
 	ProjectId         []models.Id `form:"projectId" json:"projectId"`
 	RepoRevision      string      `form:"repoRevision" json:"repoRevision" binding:""`

--- a/portal/models/forms/variable.go
+++ b/portal/models/forms/variable.go
@@ -6,13 +6,22 @@ import "cloudiac/portal/models"
 
 type BatchUpdateVariableForm struct {
 	BaseForm
-	TplId             models.Id   `json:"tplId" form:"tplId" ` // 模板id
-	EnvId             models.Id   `json:"envId" form:"envId" ` // 环境id
-	Variables         []Variables `json:"variables" form:"variables" `
-	DeleteVariablesId []string    `json:"deleteVariablesId" form:"deleteVariablesId" ` //变量id
+	TplId             models.Id  `json:"tplId" form:"tplId" ` // 模板id
+	EnvId             models.Id  `json:"envId" form:"envId" ` // 环境id
+	Variables         []Variable `json:"variables" form:"variables" `
+	DeleteVariablesId []string   `json:"deleteVariablesId" form:"deleteVariablesId" ` //变量id
 }
 
-type Variables struct {
+type UpdateObjectVarsForm struct {
+	BaseForm
+
+	Scope    string    `json:"scope" form:"scope" binding:"required" swaggerignore:"true"` // 变量作用域, enum:('org','template','project','env')
+	ObjectId models.Id `json:"objectId" binding:"required" swaggerignore:"true"`           // 变量所属实例 id
+
+	Variables []Variable `json:"variables" form:"variables" binding:"required"` // 变量列表
+}
+
+type Variable struct {
 	Id          models.Id       `json:"id" form:"id" `
 	Scope       string          `json:"scope" form:"scope" `             // 应用范围 ('org','template','project','env')
 	Type        string          `json:"type" form:"type" `               // 类型 ('environment','terraform','ansible')

--- a/portal/models/models.go
+++ b/portal/models/models.go
@@ -93,6 +93,7 @@ func UpdateAttr(tx *db.Session, o Modeler, values Attrs, query ...interface{}) (
 	})
 }
 
+// 更新 model 的非 zero value 字段值到 db
 func UpdateModel(tx *db.Session, o Modeler, query ...interface{}) (int64, error) {
 	return withTx(tx, func(x *db.Session) (int64, error) {
 		if err := o.Validate(); err != nil {
@@ -106,6 +107,11 @@ func UpdateModel(tx *db.Session, o Modeler, query ...interface{}) (int64, error)
 			return x.Model(o).Where(query[0], query[1:]...).Update(o)
 		}
 	})
+}
+
+// 更新 model 的所有字段值到 db，即使其值为 zero value
+func UpdateModelAll(tx *db.Session, o Modeler, query ...interface{}) (int64, error) {
+	return UpdateModel(tx.Select("*"), o, query...)
 }
 
 func MustMarshalValue(v interface{}) driver.Value {

--- a/portal/models/variables.go
+++ b/portal/models/variables.go
@@ -8,15 +8,15 @@ import (
 )
 
 type VariableBody struct {
+	Scope       string `json:"scope" gorm:"not null;type:enum('org','template','project','env')"`
+	Type        string `json:"type" gorm:"not null;type:enum('environment','terraform','ansible')"`
+	Name        string `json:"name" gorm:"size:64;not null"`
+	Value       string `json:"value" gorm:"type:text"`
+	Sensitive   bool   `json:"sensitive,omitempty" gorm:"default:false"`
+	Description string `json:"description,omitempty" gorm:"type:text"`
 
 	// 继承关系依赖数据创建枚举的顺序，后续新增枚举值时请按照新的继承顺序增加
-	Options     StrSlice `json:"options" gorm:"type:json"`
-	Scope       string   `json:"scope" gorm:"not null;type:enum('org','template','project','env')"`
-	Type        string   `json:"type" gorm:"not null;type:enum('environment','terraform','ansible')"`
-	Name        string   `json:"name" gorm:"size:64;not null"`
-	Value       string   `json:"value" gorm:"type:text"`
-	Sensitive   bool     `json:"sensitive,omitempty" gorm:"default:false"`
-	Description string   `json:"description,omitempty" gorm:"type:text"`
+	Options StrSlice `json:"options" gorm:"type:json"`
 }
 
 type Variable struct {

--- a/portal/services/env.go
+++ b/portal/services/env.go
@@ -119,6 +119,10 @@ func QueryActiveEnv(query *db.Session) *db.Session {
 	return query.Model(&models.Env{}).Where("status != ? OR deploying = ?", models.EnvStatusInactive, true)
 }
 
+func QueryEnv(query *db.Session) *db.Session {
+	return query.Model(&models.Env{})
+}
+
 // ChangeEnvStatusWithTaskAndStep 基于任务和步骤的状态更新环境状态
 func ChangeEnvStatusWithTaskAndStep(tx *db.Session, id models.Id, task *models.Task, step *models.TaskStep) e.Error {
 	var (
@@ -235,7 +239,7 @@ func GetSampleValidVariables(tx *db.Session, orgId, projectId, tplId, envId mode
 	for _, v := range sampleVariables {
 		isNew := true
 		for key, value := range vars {
-			// 
+			//
 			if v.Name == fmt.Sprintf("TF_VAR_%s", value.Name) {
 				resp = append(resp, forms.Variable{
 					Id:    vars[key].Id,

--- a/portal/services/env.go
+++ b/portal/services/env.go
@@ -226,8 +226,8 @@ func GetDefaultRunner() (string, e.Error) {
 	return "", e.New(e.ConsulConnError, fmt.Errorf("runner list is null"))
 }
 
-func GetSampleValidVariables(tx *db.Session, orgId, projectId, tplId, envId models.Id, sampleVariables []forms.SampleVariables) ([]forms.Variables, e.Error) {
-	resp := make([]forms.Variables, 0)
+func GetSampleValidVariables(tx *db.Session, orgId, projectId, tplId, envId models.Id, sampleVariables []forms.SampleVariables) ([]forms.Variable, e.Error) {
+	resp := make([]forms.Variable, 0)
 	vars, err, _ := GetValidVariables(tx, consts.ScopeEnv, orgId, projectId, tplId, envId, true)
 	if err != nil {
 		return nil, e.New(e.DBError, fmt.Errorf("get vairables error: %v", err))
@@ -237,7 +237,7 @@ func GetSampleValidVariables(tx *db.Session, orgId, projectId, tplId, envId mode
 		for key, value := range vars {
 			// 
 			if v.Name == fmt.Sprintf("TF_VAR_%s", value.Name) {
-				resp = append(resp, forms.Variables{
+				resp = append(resp, forms.Variable{
 					Id:    vars[key].Id,
 					Scope: vars[key].Scope,
 					Type:  vars[key].Type,
@@ -253,7 +253,7 @@ func GetSampleValidVariables(tx *db.Session, orgId, projectId, tplId, envId mode
 		}
 		// 对不在变量列表的变量进行新建
 		if isNew {
-			resp = append(resp, forms.Variables{
+			resp = append(resp, forms.Variable{
 				Scope: consts.ScopeEnv,
 				Type:  consts.VarTypeEnv,
 				Name:  v.Name,

--- a/portal/services/user.go
+++ b/portal/services/user.go
@@ -243,6 +243,10 @@ func QueryWithProjectId(query *db.Session, projectId interface{}, tableName ...s
 	return QueryWithCond(query, "project_id", projectId, tableName...)
 }
 
+func QueryWithOrgProject(query *db.Session, orgId interface{}, projId interface{}, tableName ...string) *db.Session {
+	return QueryWithProjectId(QueryWithOrgId(query, orgId, tableName...), projId, tableName...)
+}
+
 func QueryWithCond(query *db.Session, column string, value interface{}, tableName ...string) *db.Session {
 	if len(tableName) > 0 {
 		return query.Where(fmt.Sprintf("`%s`.`%s` = ?", tableName[0], column), value)

--- a/portal/services/variables.go
+++ b/portal/services/variables.go
@@ -48,8 +48,8 @@ func SearchVariableByTemplateId(tx *db.Session, tplId models.Id) ([]models.Varia
 }
 
 func OperationVariables(tx *db.Session, orgId, projectId, tplId, envId models.Id,
-	variables []forms.Variables, deleteVariablesId []string) e.Error {
-	if err := DeleteVariables(tx, deleteVariablesId); err != nil {
+	variables []forms.Variable, deleteVariablesId []string) e.Error {
+	if err := deleteVariables(tx, deleteVariablesId); err != nil {
 		return err
 	}
 
@@ -78,7 +78,7 @@ func OperationVariables(tx *db.Session, orgId, projectId, tplId, envId models.Id
 
 		//id不为空修改变量，反之新建
 		if v.Id != "" {
-			err := UpdateVariable(tx, v.Id, attrs)
+			err := updateVariable(tx, v.Id, attrs)
 			if err != nil && err.Code() == e.VariableAliasDuplicate {
 				return e.New(err.Code(), err, http.StatusBadRequest)
 			} else if err != nil {
@@ -93,13 +93,13 @@ func OperationVariables(tx *db.Session, orgId, projectId, tplId, envId models.Id
 			}
 		}
 	}
-	if err := CreateVariables(tx, bq); err != nil {
+	if err := createVariables(tx, bq); err != nil {
 		return err
 	}
 	return nil
 }
 
-func CreateVariables(tx *db.Session, bq *utils.BatchSQL) e.Error {
+func createVariables(tx *db.Session, bq *utils.BatchSQL) e.Error {
 	for bq.HasNext() {
 		sql, args := bq.Next()
 		if _, err := tx.Exec(sql, args...); err != nil {
@@ -109,7 +109,7 @@ func CreateVariables(tx *db.Session, bq *utils.BatchSQL) e.Error {
 	return nil
 }
 
-func UpdateVariable(tx *db.Session, variableId models.Id, attr map[string]interface{}) e.Error {
+func updateVariable(tx *db.Session, variableId models.Id, attr map[string]interface{}) e.Error {
 	if _, err := models.UpdateAttr(tx,
 		models.Variable{BaseModel: models.BaseModel{Id: variableId}}, attr); err != nil {
 		if e.IsDuplicate(err) {
@@ -120,11 +120,11 @@ func UpdateVariable(tx *db.Session, variableId models.Id, attr map[string]interf
 	return nil
 }
 
-func DeleteVariables(tx *db.Session, DeleteVariables []string) e.Error {
-	if len(DeleteVariables) == 0 {
+func deleteVariables(tx *db.Session, varIds []string) e.Error {
+	if len(varIds) == 0 {
 		return nil
 	}
-	if _, err := tx.Where("id in (?)", DeleteVariables).Delete(&models.Variable{}); err != nil {
+	if _, err := tx.Where("id IN (?)", varIds).Delete(&models.Variable{}); err != nil {
 		return e.New(e.DBError, fmt.Errorf("delete variables error: %v", err))
 	}
 	return nil
@@ -248,4 +248,107 @@ func GetVariableBody(vars map[string]models.Variable) []models.VariableBody {
 
 func QueryVariable(dbSess *db.Session) *db.Session {
 	return dbSess.Model(&models.Variable{})
+}
+
+// UpdateObjectVars 更新(或新增)实例的变量
+// vars 参数为待更新的变量,
+// 该函数为全量更新，vars 中不存在的变量会从实例的变量列表中删除，己存在的同名变量会被更新，新增变量会创建
+func UpdateObjectVars(tx *db.Session, scope string, objectId models.Id, vars []models.Variable) ([]models.Variable, e.Error) {
+	table := models.Variable{}.TableName()
+
+	varsMap := make(map[string]models.Variable)
+	for i, v := range vars {
+		var err error
+		if v.Sensitive {
+			if v.Value != "" {
+				v.Value, err = utils.EncryptSecretVar(v.Value)
+				if err != nil {
+					return nil, e.AutoNew(err, e.EncryptError)
+				}
+				vars[i] = v
+			}
+		}
+		varsMap[v.Name] = vars[i]
+	}
+
+	dbVars := make([]models.Variable, 0)
+	if err := WithVarScopeIdWhere(tx, table, scope, objectId).Find(&dbVars); err != nil {
+		return nil, e.AutoNew(err, e.DBError)
+	}
+	dbVarsMap := make(map[string]models.Variable)
+	for _, v := range dbVars {
+		dbVarsMap[v.Name] = v
+	}
+
+	// 删除实例己有，但此次未提交的变量
+	delVarNames := make([]string, 0)
+	for _, v := range dbVars {
+		if _, ok := varsMap[v.Name]; !ok {
+			delVarNames = append(delVarNames, v.Name)
+		}
+	}
+	if _, err := WithVarScopeIdWhere(tx, table, scope, objectId).
+		Where("name IN (?)", delVarNames).Delete(&models.Variable{}); err != nil {
+		return nil, e.AutoNew(err, e.DBError)
+	}
+
+	insertSqls := utils.NewBatchSQL(1024, "INSERT INTO", models.Variable{}.TableName(),
+		"org_id", "project_id", "tpl_id", "env_id",
+		"id", "scope", "type", "name", "value", "sensitive", "description", "options")
+
+	for _, v := range vars {
+		if dbVar, ok := dbVarsMap[v.Name]; ok { // 同名变量己存在，进行更新
+			// 如果没有传 id 则使用己有的 id
+			if v.Id == "" {
+				v.Id = dbVar.Id
+			}
+			if _, err := models.UpdateModelAll(tx, v, "id = ?", dbVar.Id); err != nil {
+				return nil, e.AutoNew(err, e.DBError)
+			}
+		} else { // 否则插入新变量
+			insertSqls.MustAddRow(v.OrgId, v.ProjectId, v.TplId, v.EnvId,
+				v.NewId(), v.Scope, v.Type, v.Name, v.Value, v.Sensitive, v.Description, v.Options)
+		}
+	}
+
+	for insertSqls.HasNext() {
+		sql, args := insertSqls.Next()
+		if _, err := tx.Exec(sql, args...); err != nil {
+			return nil, e.AutoNew(err, e.DBError)
+		}
+	}
+
+	retVars := make([]models.Variable, 0)
+	if err := WithVarScopeIdWhere(tx, table, scope, objectId).Find(&retVars); err != nil {
+		return nil, e.AutoNew(err, e.DBError)
+	}
+	return retVars, nil
+}
+
+func WithVarScopeIdWhere(query *db.Session, tableName string, scope string, id models.Id) *db.Session {
+	query = query.Where(fmt.Sprintf("`%s`.`scope` = ?", tableName), scope)
+	switch scope {
+	case consts.ScopeOrg:
+		return query.Where("org_id = ?", id)
+	case consts.ScopeProject:
+		return query.Where("project_id = ?", id)
+	case consts.ScopeTemplate:
+		return query.Where("tpl_id = ?", id)
+	case consts.ScopeEnv:
+		return query.Where("env_id = ?", id)
+	default:
+		panic(fmt.Errorf("unknown variable scope '%v'", scope))
+	}
+}
+
+// VarsDesensitization 变量脱敏(将 sensitive 变量的 value 设置为空字符串)
+func VarsDesensitization(vars []models.Variable) []models.Variable {
+	retVars := make([]models.Variable, 0, len(vars))
+	for _, v := range vars {
+		if v.Sensitive {
+			v.Value = ""
+		}
+		retVars = append(retVars, v)
+	}
+	return retVars
 }

--- a/portal/web/api/v1/handlers/variable.go
+++ b/portal/web/api/v1/handlers/variable.go
@@ -6,6 +6,7 @@ import (
 	"cloudiac/portal/apps"
 	"cloudiac/portal/libs/ctrl"
 	"cloudiac/portal/libs/ctx"
+	"cloudiac/portal/models"
 	"cloudiac/portal/models/forms"
 )
 
@@ -13,7 +14,7 @@ type Variable struct {
 	ctrl.GinController
 }
 
-// BatchUpdate 批量修改变量
+// BatchUpdate 批量修改变量(己弃用)
 // @Tags 变量
 // @Summary 批量修改变量
 // @Accept json
@@ -23,13 +24,37 @@ type Variable struct {
 // @Param IaC-Project-Id header string false "项目ID"
 // @Param form body forms.BatchUpdateVariableForm true "parameter"
 // @router /variables/batch [put]
-// @Success 200 {object} ctx.JSONResult{result=models.Variable}
+// @Success 200 {object} ctx.JSONResult{}
 func (Variable) BatchUpdate(c *ctx.GinRequest) {
 	form := forms.BatchUpdateVariableForm{}
 	if err := c.Bind(&form); err != nil {
 		return
 	}
 	c.JSONResult(apps.BatchUpdate(c.Service(), &form))
+}
+
+// UpdateObjectVars 更新实例的变量
+// @Tags 变量
+// @Summary 更新实例的变量
+// @Description 该接口全量更新实例的变量列表，缺少的变量会被创建，多余的变量会被删除
+// @Accept json
+// @Produce json
+// @Security AuthToken
+// @Param IaC-Org-Id header string true "组织ID"
+// @Param IaC-Project-Id header string false "项目ID"
+// @Param scope path string true "变量的作用域(即实例类型)" enums(org,template,project,env)
+// @Param objectId path string true "变量关联的实例 id"
+// @Param form body forms.UpdateObjectVarsForm true "parameter"
+// @router /variables/scope/{scope}/{objectId} [put]
+// @Success 200 {object} ctx.JSONResult{result=[]models.Variable}
+func (Variable) UpdateObjectVars(c *ctx.GinRequest) {
+	form := forms.UpdateObjectVarsForm{}
+	form.Scope = c.Param("scope")
+	form.ObjectId = models.Id(c.Param("id"))
+	if err := c.Bind(&form); err != nil {
+		return
+	}
+	c.JSONResult(apps.UpdateObjectVars(c.Service(), &form))
 }
 
 // Search 查询变量
@@ -69,4 +94,3 @@ func (Variable) SearchSampleVariable(c *ctx.GinRequest) {
 	}
 	c.JSONResult(apps.SearchSampleVariable(c.Service(), &form))
 }
-

--- a/portal/web/api/v1/route.go
+++ b/portal/web/api/v1/route.go
@@ -122,12 +122,14 @@ func Register(g *gin.RouterGroup) {
 
 	//项目管理
 	ctrl.Register(g.Group("projects", ac()), &handlers.Project{})
+
 	//变量管理
 	g.PUT("/variables/batch", ac(), w(handlers.Variable{}.BatchUpdate))
-
+	g.PUT("/variables/scope/:scope/:id", ac(), w(handlers.Variable{}.UpdateObjectVars))
 	// 供第三方系统获取变量的接口，该接口将 terraform 变量和环境变量统一转为环境变量格式返回，方便第三方系统处理
 	g.GET("/variables/sample", ac(), w(handlers.Variable{}.SearchSampleVariable))
 	ctrl.Register(g.Group("variables", ac()), &handlers.Variable{})
+
 	// 变量组
 	ctrl.Register(g.Group("var_groups", ac()), &handlers.VariableGroup{})
 	g.GET("/var_groups/relationship", ac(), w(handlers.VariableGroup{}.SearchRelationship))


### PR DESCRIPTION
- 新增接口: /variables/scope/{scope}/{objectId}，用于更新实例的变量列表
- 修改环境创建接口：variables 参数只支持传入环境级别的变量
- 修改环境部署接口：移除 delVariables 参数，variables 参数设计为全量更新, variables 中不存在的变量会被删除

resolve #68 