### PR TITLE
change: 修改 mysql table 的 collate 为 utf8mb4

### DIFF
--- a/portal/models/models.go
+++ b/portal/models/models.go
@@ -169,6 +169,12 @@ func autoMigrate(m Modeler, sess *db.Session) {
 	if err := sess.GormDB().AutoMigrate(m); err != nil {
 		panic(fmt.Errorf("auto migrate %T: %v", m, err))
 	}
+
+	// 强制修改 table 的字符集和 collate
+	if _, err := sess.Exec(fmt.Sprintf("ALTER TABLE `%s` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci", m.TableName())); err != nil {
+		panic(err)
+	}
+
 	if err := m.Migrate(sess); err != nil {
 		panic(fmt.Errorf("auto migrate %T: %v", m, err))
 	}
@@ -177,7 +183,7 @@ func autoMigrate(m Modeler, sess *db.Session) {
 func Init(migrate bool) {
 	autoMigration = migrate
 
-	sess := db.Get().Set("gorm:table_options", "ENGINE=InnoDB").Begin()
+	sess := db.Get().Set("gorm:table_options", "ENGINE=InnoDB CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci").Begin()
 	defer func() {
 		logger := logs.Get().WithField("func", "models.Init")
 		if r := recover(); r != nil {


### PR DESCRIPTION
升级到 mysql 8.0 后默认会使用 utf8mb4_0900_ci，但 5.7 版本默认为 utf8_general_ci，
当字段值有特殊符号时(如 emoji 符号) 将无法进行两种类型的转换，所以需要统一 collection。

又因为我们需要同时兼容 mysql 5.7 和 8.0，utf8mb4_0900_ci 在 5.7 中还未引入，所以选择 utf8mb4_unicode_ci。