### PR TITLE
fix: 云模板解析只解析 terraform 文件

### DIFF
--- a/runner/task.go
+++ b/runner/task.go
@@ -527,7 +527,7 @@ var parseCommandTpl = template.Must(template.New("").Parse(`#!/bin/sh
 cd 'code/{{.Req.Env.Workdir}}' && \
 mkdir -p {{.PoliciesDir}} && \
 mkdir -p ~/.terrascan/pkg/policies/opa/rego/aws && \
-terrascan scan --config-only -l debug -o json > {{.TFScanJsonFilePath}}
+terrascan scan --config-only -l debug -o json --iac-type terraform > {{.TFScanJsonFilePath}}
 `))
 
 func (t *Task) stepTfParse() (command string, err error) {


### PR DESCRIPTION
terrascan 1.9 会把 Dockerfile 解析出来，并且格式和 terraform 的有点不一样，导致 json unmarshal 出错，添加限制为只解析 terraform 文件。