### PR TITLE
fix: 修复部分查询未正常处理软删除的问题

### DIFF
--- a/portal/libs/db/mysql_gorm.go
+++ b/portal/libs/db/mysql_gorm.go
@@ -128,14 +128,10 @@ func (s *Session) Commit() error {
 }
 
 func (s *Session) Model(m interface{}) *Session {
-	switch v := m.(type) {
-	case string:
-		return s.Table(v)
-	default:
-		return ToSess(s.db.Model(m))
-	}
+	return ToSess(s.db.Model(m))
 }
 
+// 注意: Table() 与 Model() 不同的是，使用 Table() 时不会自动处理 delete_at_t 字段
 func (s *Session) Table(name string, args ...interface{}) *Session {
 	return ToSess(s.db.Table(name, args...))
 }

--- a/portal/models/policy.go
+++ b/portal/models/policy.go
@@ -10,7 +10,7 @@ import (
 const MaxTagSize = 16
 
 type Policy struct {
-	SoftDeleteModel
+	TimedModel
 
 	GroupId   Id `json:"groupId" gorm:"size:32;comment:策略组ID" example:"lg-c3lcrjxczjdywmk0go90"`
 	CreatorId Id `json:"creatorId" gorm:"size:32;not null;创建人" example:"u-c3lcrjxczjdywmk0go90"`
@@ -32,6 +32,14 @@ type Policy struct {
 
 func (Policy) TableName() string {
 	return "iac_policy"
+}
+
+func (*Policy) Migrate(sess *db.Session) error {
+	if err := sess.DropColumn(Policy{}, "deleted_at_t"); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (p *Policy) CustomBeforeCreate(*db.Session) error {

--- a/portal/services/project.go
+++ b/portal/services/project.go
@@ -23,7 +23,7 @@ func CreateProject(tx *db.Session, project *models.Project) (*models.Project, e.
 }
 
 func SearchProject(dbSess *db.Session, orgId models.Id, q, status string) *db.Session {
-	query := dbSess.Table(models.Project{}.TableName()).Where(fmt.Sprintf("%s.org_id = ?", models.Project{}.TableName()), orgId)
+	query := dbSess.Model(&models.Project{}).Where(fmt.Sprintf("%s.org_id = ?", models.Project{}.TableName()), orgId)
 	if q != "" {
 		query = query.Where(fmt.Sprintf("%s.name like ?", models.Project{}.TableName()), fmt.Sprintf("%%%s%%", q))
 	}
@@ -78,7 +78,7 @@ func StatisticalProjectEnv(dbSess *db.Session, projectId models.Id) (*struct {
 		envInactive int64
 	)
 
-	if err := dbSess.Table(models.Env{}.TableName()).Select("count(status) as count, status").
+	if err := dbSess.Model(&models.Env{}).Select("count(status) as count, status").
 		Where("project_id = ?", projectId).Group("status").Find(&resp); err != nil {
 		return nil, err
 	}

--- a/portal/services/template.go
+++ b/portal/services/template.go
@@ -82,7 +82,7 @@ func QueryTemplateByOrgId(tx *db.Session, q string, orgId models.Id, templateIdL
 }
 
 func QueryTplByProjectId(tx *db.Session, projectId models.Id) (tplIds []models.Id, err e.Error) {
-	if err := tx.Table(models.ProjectTemplate{}.TableName()).
+	if err := tx.Model(&models.ProjectTemplate{}).
 		Where("project_id = ?", projectId).
 		Pluck("template_id", &tplIds); err != nil {
 		return nil, e.AutoNew(err, e.DBError)
@@ -91,7 +91,7 @@ func QueryTplByProjectId(tx *db.Session, projectId models.Id) (tplIds []models.I
 }
 
 func QueryProjectByTplId(tx *db.Session, tplId models.Id) (projectIds []models.Id, err e.Error) {
-	if err := tx.Table(models.ProjectTemplate{}.TableName()).
+	if err := tx.Model(&models.ProjectTemplate{}).
 		Where("template_id = ?", tplId).
 		Pluck("project_id", &projectIds); err != nil {
 		return nil, e.AutoNew(err, e.DBError)

--- a/portal/services/user.go
+++ b/portal/services/user.go
@@ -119,7 +119,7 @@ func CheckPasswordFormat(password string) e.Error {
 func GetUserDetailById(query *db.Session, userId models.Id) (*models.UserWithRoleResp, e.Error) {
 	d := models.UserWithRoleResp{}
 	table := models.User{}.TableName()
-	if err := query.Table(table).Where(fmt.Sprintf("%s.id = ?", table), userId).First(&d); err != nil {
+	if err := query.Model(&models.User{}).Where(fmt.Sprintf("%s.id = ?", table), userId).First(&d); err != nil {
 		if e.IsRecordNotFound(err) {
 			return nil, e.New(e.UserNotExists, err)
 		}

--- a/portal/services/vcsrv/vcservice.go
+++ b/portal/services/vcsrv/vcservice.go
@@ -10,8 +10,9 @@ import (
 	"cloudiac/portal/models"
 	"cloudiac/utils"
 	"fmt"
-	"github.com/pkg/errors"
 	"path"
+
+	"github.com/pkg/errors"
 )
 
 /*
@@ -167,7 +168,7 @@ func SetWebhook(vcs *models.Vcs, repoId, apiToken string, triggers []string) err
 	//空值时删除
 	if len(triggers) == 0 {
 		// 判断同vcs、仓库的环境是否存在
-		exist, err := db.Get().Table(models.Env{}.TableName()).
+		exist, err := db.Get().Model(&models.Env{}).
 			Joins("left join iac_template as tpl on iac_env.tpl_id = tpl.id").
 			Where("tpl.vcs_id = ?", vcs.Id).
 			Where("iac_env.triggers IS NOT NULL or iac_env.triggers != '{}'").Exists()


### PR DESCRIPTION
使用 Table() 时不会自动处理软删除，所以需要进行修复。
目前使用软删除特性的 model 有: env、policy、project、runner_task、template、user。
其中 policy 在 0.9 版本中会从 vcs 中导入，所有不再需要软删除。
其他 model 使用了 Table() 调用的地方都改为了 Model() 或者其查询语句中己经加上了 deleted_at_t = 0 条件