### PR TITLE
fix: 查询用户详情报 user.role 字段不存在

### DIFF
--- a/portal/services/user.go
+++ b/portal/services/user.go
@@ -119,7 +119,8 @@ func CheckPasswordFormat(password string) e.Error {
 func GetUserDetailById(query *db.Session, userId models.Id) (*models.UserWithRoleResp, e.Error) {
 	d := models.UserWithRoleResp{}
 	table := models.User{}.TableName()
-	if err := query.Model(&models.User{}).Where(fmt.Sprintf("%s.id = ?", table), userId).First(&d); err != nil {
+	if err := query.Model(&models.User{}).
+		Where(fmt.Sprintf("%s.id = ?", table), userId).Scan(&d); err != nil {
 		if e.IsRecordNotFound(err) {
 			return nil, e.New(e.UserNotExists, err)
 		}


### PR DESCRIPTION
使用 db.First(&dest) 查询数据时总是使用 First() 传入的 struct 做字段映射,
前面通过的 Model() 指定的 struct 不生效。