### PR TITLE
feat: registry home url 配置及初始化

### DIFF
--- a/cmds/portal/main.go
+++ b/cmds/portal/main.go
@@ -254,7 +254,7 @@ func initVcs(tx *db.Session) error {
 	}
 
 	dbVcs := models.Vcs{}
-	err := services.QueryVcs("", "", "", true, tx).First(&dbVcs)
+	err := services.QueryVcs("", "", "", true, false, tx).First(&dbVcs)
 	if err != nil && !e.IsRecordNotFound(err) {
 		return err
 	}
@@ -286,7 +286,7 @@ func initRegistryVcs(tx *db.Session) error {
 	}
 
 	dbVcs := models.Vcs{}
-	err := services.QueryVcs("", "", "registry仓库", true, tx).First(&dbVcs)
+	err := services.QueryVcs("", "", "registry仓库", false, true, tx).First(&dbVcs)
 	if err != nil && !e.IsRecordNotFound(err) {
 		return err
 	}

--- a/configs/config-portal.yml.sample
+++ b/configs/config-portal.yml.sample
@@ -3,6 +3,7 @@ mysql: "${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(${MYSQL_HOST}:${MYSQL_PORT})/${MYSQL
 
 secretKey: "${SECRET_KEY}"
 jwtSecretKey: "${JWT_SECRET_KEY}"
+registryAddr: "${REGISTRY_ADDR}"
 
 portal:
   address: "${PORTAL_ADDRESS}"

--- a/configs/config.go
+++ b/configs/config.go
@@ -130,6 +130,7 @@ type Config struct {
 	SMTPServer   SMTPServerConfig `yaml:"smtpServer"`
 	SecretKey    string           `yaml:"secretKey"`
 	JwtSecretKey string           `yaml:"jwtSecretKey"`
+	RegistryAddr string           `yaml:"registryAddr"`
 
 	ExportSecretKey string `yaml:"exportSecretKey"`
 

--- a/portal/apps/system_config.go
+++ b/portal/apps/system_config.go
@@ -57,3 +57,8 @@ func UpdateSystemConfig(c *ctx.ServiceContext, form *forms.UpdateSystemConfigFor
 
 	return nil, nil
 }
+
+func CheckRegistryAddr(c *ctx.ServiceContext) (interface{}, e.Error) {
+
+	return nil, nil
+}

--- a/portal/apps/system_config.go
+++ b/portal/apps/system_config.go
@@ -3,6 +3,7 @@
 package apps
 
 import (
+	"cloudiac/configs"
 	"cloudiac/portal/consts/e"
 	"cloudiac/portal/libs/ctx"
 	"cloudiac/portal/models"
@@ -59,6 +60,22 @@ func UpdateSystemConfig(c *ctx.ServiceContext, form *forms.UpdateSystemConfigFor
 }
 
 func CheckRegistryAddr(c *ctx.ServiceContext) (interface{}, e.Error) {
+	// check db
+	cfg, err := services.GetSystemConfigByName(c.DB(), models.SysCfgNamRegistryAddr)
+	if err == nil && cfg != nil {
+		return map[string]interface{}{
+			"isExisted": true,
+		}, nil
+	}
 
-	return nil, nil
+	// check config file
+	if configs.Get().RegistryAddr != "" {
+		return map[string]interface{}{
+			"isExisted": true,
+		}, nil
+	}
+
+	return map[string]interface{}{
+		"isExisted": false,
+	}, nil
 }

--- a/portal/apps/system_config.go
+++ b/portal/apps/system_config.go
@@ -79,3 +79,14 @@ func CheckRegistryAddr(c *ctx.ServiceContext) (interface{}, e.Error) {
 		IsExisted: false,
 	}, nil
 }
+
+func GetRegistryAddr(c *ctx.ServiceContext) (interface{}, e.Error) {
+	cfg, err := services.GetSystemConfigByName(c.DB(), models.SysCfgNamRegistryAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &models.RegistryAddrResp{
+		RegistryAddr: cfg.Value,
+	}, nil
+}

--- a/portal/apps/system_config.go
+++ b/portal/apps/system_config.go
@@ -61,7 +61,7 @@ func UpdateSystemConfig(c *ctx.ServiceContext, form *forms.UpdateSystemConfigFor
 
 func CheckRegistryAddr(c *ctx.ServiceContext) (interface{}, e.Error) {
 	// check db
-	cfg, err := services.GetSystemConfigByName(c.DB(), models.SysCfgNamRegistryAddr)
+	cfg, err := services.GetSystemConfigByName(c.DB(), models.SysCfgNamRegistryHome)
 	if err == nil && cfg != nil {
 		return &models.RegistryAddrCheckResp{
 			IsExisted: true,
@@ -81,7 +81,7 @@ func CheckRegistryAddr(c *ctx.ServiceContext) (interface{}, e.Error) {
 }
 
 func GetRegistryAddr(c *ctx.ServiceContext) (interface{}, e.Error) {
-	cfg, err := services.GetSystemConfigByName(c.DB(), models.SysCfgNamRegistryAddr)
+	cfg, err := services.GetSystemConfigByName(c.DB(), models.SysCfgNamRegistryHome)
 	if err != nil {
 		return nil, err
 	}

--- a/portal/apps/system_config.go
+++ b/portal/apps/system_config.go
@@ -90,3 +90,15 @@ func GetRegistryAddr(c *ctx.ServiceContext) (interface{}, e.Error) {
 		RegistryAddr: cfg.Value,
 	}, nil
 }
+
+func UpsertRegistryAddr(c *ctx.ServiceContext, form *forms.RegistryAddrForm) (interface{}, e.Error) {
+
+	cfg, err := services.UpsertRegistryAddr(c.DB(), form.RegistryAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &models.RegistryAddrResp{
+		RegistryAddr: cfg.Value,
+	}, nil
+}

--- a/portal/apps/system_config.go
+++ b/portal/apps/system_config.go
@@ -59,46 +59,29 @@ func UpdateSystemConfig(c *ctx.ServiceContext, form *forms.UpdateSystemConfigFor
 	return nil, nil
 }
 
-func CheckRegistryAddr(c *ctx.ServiceContext) (interface{}, e.Error) {
-	// check db
-	cfg, err := services.GetSystemConfigByName(c.DB(), models.SysCfgNamRegistryHome)
-	if err == nil && cfg != nil {
-		return &models.RegistryAddrCheckResp{
-			IsExisted: true,
-		}, nil
-	}
-
-	// check config file
-	if configs.Get().RegistryAddr != "" {
-		return &models.RegistryAddrCheckResp{
-			IsExisted: true,
-		}, nil
-	}
-
-	return &models.RegistryAddrCheckResp{
-		IsExisted: false,
-	}, nil
-}
-
 func GetRegistryAddr(c *ctx.ServiceContext) (interface{}, e.Error) {
 	cfg, err := services.GetSystemConfigByName(c.DB(), models.SysCfgNamRegistryHome)
-	if err != nil {
-		return nil, err
+	var cfgdb = ""
+	if err == nil {
+		cfgdb = cfg.Value
 	}
 
 	return &models.RegistryAddrResp{
-		RegistryAddr: cfg.Value,
+		RegistryAddrFromDB:  cfgdb,
+		RegistryAddrFromCfg: configs.Get().RegistryAddr,
 	}, nil
 }
 
 func UpsertRegistryAddr(c *ctx.ServiceContext, form *forms.RegistryAddrForm) (interface{}, e.Error) {
 
 	cfg, err := services.UpsertRegistryAddr(c.DB(), form.RegistryAddr)
-	if err != nil {
-		return nil, err
+	var cfgdb = ""
+	if err == nil {
+		cfgdb = cfg.Value
 	}
 
 	return &models.RegistryAddrResp{
-		RegistryAddr: cfg.Value,
+		RegistryAddrFromDB:  cfgdb,
+		RegistryAddrFromCfg: configs.Get().RegistryAddr,
 	}, nil
 }

--- a/portal/apps/system_config.go
+++ b/portal/apps/system_config.go
@@ -63,19 +63,19 @@ func CheckRegistryAddr(c *ctx.ServiceContext) (interface{}, e.Error) {
 	// check db
 	cfg, err := services.GetSystemConfigByName(c.DB(), models.SysCfgNamRegistryAddr)
 	if err == nil && cfg != nil {
-		return map[string]interface{}{
-			"isExisted": true,
+		return &models.RegistryAddrCheckResp{
+			IsExisted: true,
 		}, nil
 	}
 
 	// check config file
 	if configs.Get().RegistryAddr != "" {
-		return map[string]interface{}{
-			"isExisted": true,
+		return &models.RegistryAddrCheckResp{
+			IsExisted: true,
 		}, nil
 	}
 
-	return map[string]interface{}{
-		"isExisted": false,
+	return &models.RegistryAddrCheckResp{
+		IsExisted: false,
 	}, nil
 }

--- a/portal/apps/vcs.go
+++ b/portal/apps/vcs.go
@@ -81,7 +81,7 @@ func UpdateVcs(c *ctx.ServiceContext, form *forms.UpdateVcsForm) (vcs *models.Vc
 }
 
 func SearchVcs(c *ctx.ServiceContext, form *forms.SearchVcsForm) (interface{}, e.Error) {
-	rs, err := getPage(services.QueryVcs(c.OrgId, form.Status, form.Q, form.IsShowDefaultVcs, c.DB()), form, models.Vcs{})
+	rs, err := getPage(services.QueryVcs(c.OrgId, form.Status, form.Q, form.IsShowDefaultVcs, false, c.DB()), form, models.Vcs{})
 	if err != nil {
 		return nil, err
 	}

--- a/portal/consts/consts.go
+++ b/portal/consts/consts.go
@@ -32,7 +32,6 @@ const (
 
 	DefaultTerraformVersion = "0.14.11"
 
-
 	// token subject
 	JwtSubjectUserAuth = "userAuth" // 用于用户认证
 	JwtSubjectSsoCode  = "ssoCode"  // 用于 sso 单点登录
@@ -56,11 +55,12 @@ const (
 	TerraformVar           = "TF_VAR_"
 	WorkFlow               = "workflow"
 
-	GitTypeGitLab = "gitlab"
-	GitTypeGitEA  = "gitea"
-	GitTypeGithub = "github"
-	GitTypeGitee  = "gitee"
-	GitTypeLocal  = "local"
+	GitTypeGitLab   = "gitlab"
+	GitTypeGitEA    = "gitea"
+	GitTypeGithub   = "github"
+	GitTypeGitee    = "gitee"
+	GitTypeLocal    = "local"
+	GitTypeRegistry = "registry"
 
 	MetaYmlMatch   = "meta.y*ml"
 	VariablePrefix = "variables.tf"
@@ -76,6 +76,8 @@ const (
 
 	LocalGitReposPath = "repos"  // 内置 http git server 服务目录
 	ReposUrlPrefix    = "/repos" // 内置 http git server url prefix
+
+	RegistryVcsPath = "repos/policies" // registry vcs 仓库路径
 
 	NotificationMessageTitle = "CloudIaC平台系统通知"
 

--- a/portal/consts/e/errors.go
+++ b/portal/consts/e/errors.go
@@ -184,6 +184,9 @@ const (
 	//cron 315
 	CronExpressError = 31500
 	CronTaskFailed   = 31501
+
+	// system config 316
+	SystemConfigNotExist = 31610
 )
 
 var errorMsgs = map[int]map[string]string{
@@ -564,5 +567,8 @@ var errorMsgs = map[int]map[string]string{
 	},
 	PolicyRegoInvalid: {
 		"zh-cn": "rego 脚本解析无效",
+	},
+	SystemConfigNotExist: {
+		"zh-cn": "当前配置不存在",
 	},
 }

--- a/portal/models/forms/system_config.go
+++ b/portal/models/forms/system_config.go
@@ -18,3 +18,8 @@ type SystemCfg struct {
 	Value       string `form:"value" json:"value" binding:"required"`
 	Description string `form:"description" json:"description"`
 }
+
+type RegistryAddrForm struct {
+	BaseForm
+	RegistryAddr string `form:"registryAddr" json:"registryAddr" binding:"required"`
+}

--- a/portal/models/sys_cfg.go
+++ b/portal/models/sys_cfg.go
@@ -9,7 +9,7 @@ import (
 const (
 	SysCfgNameMaxJobsPerRunner = "MAX_JOBS_PER_RUNNER"
 	SysCfgNamePeriodOfLogSave  = "PERIOD_OF_LOG_SAVE"
-	SysCfgNamRegistryAddr      = "REGISTRY_ADDR"
+	SysCfgNamRegistryHome      = "REGISTRY_HOME"
 )
 
 type SystemCfg struct {

--- a/portal/models/sys_cfg.go
+++ b/portal/models/sys_cfg.go
@@ -35,3 +35,7 @@ func (o SystemCfg) Migrate(sess *db.Session) (err error) {
 type RegistryAddrCheckResp struct {
 	IsExisted bool `json:"isExisted"`
 }
+
+type RegistryAddrResp struct {
+	RegistryAddr string `json:"registryAddr"`
+}

--- a/portal/models/sys_cfg.go
+++ b/portal/models/sys_cfg.go
@@ -32,10 +32,7 @@ func (o SystemCfg) Migrate(sess *db.Session) (err error) {
 	return nil
 }
 
-type RegistryAddrCheckResp struct {
-	IsExisted bool `json:"isExisted"`
-}
-
 type RegistryAddrResp struct {
-	RegistryAddr string `json:"registryAddr"`
+	RegistryAddrFromDB  string `json:"registryAddrDB"`
+	RegistryAddrFromCfg string `json:"registryAddrCfg"`
 }

--- a/portal/models/sys_cfg.go
+++ b/portal/models/sys_cfg.go
@@ -31,3 +31,7 @@ func (o SystemCfg) Migrate(sess *db.Session) (err error) {
 	}
 	return nil
 }
+
+type RegistryAddrCheckResp struct {
+	IsExisted bool `json:"isExisted"`
+}

--- a/portal/models/sys_cfg.go
+++ b/portal/models/sys_cfg.go
@@ -9,6 +9,7 @@ import (
 const (
 	SysCfgNameMaxJobsPerRunner = "MAX_JOBS_PER_RUNNER"
 	SysCfgNamePeriodOfLogSave  = "PERIOD_OF_LOG_SAVE"
+	SysCfgNamRegistryAddr      = "REGISTRY_ADDR"
 )
 
 type SystemCfg struct {

--- a/portal/services/system_config.go
+++ b/portal/services/system_config.go
@@ -60,11 +60,11 @@ func GetSystemConfigByName(tx *db.Session, name string) (*models.SystemCfg, e.Er
 }
 
 func UpsertRegistryAddr(tx *db.Session, val string) (*models.SystemCfg, e.Error) {
-	cfg, err := GetSystemConfigByName(tx, models.SysCfgNamRegistryAddr)
+	cfg, err := GetSystemConfigByName(tx, models.SysCfgNamRegistryHome)
 	if err != nil {
 		if err.Err() == gorm.ErrRecordNotFound {
 			return CreateSystemConfig(tx, models.SystemCfg{
-				Name:  models.SysCfgNamRegistryAddr,
+				Name:  models.SysCfgNamRegistryHome,
 				Value: val,
 			})
 		} else {

--- a/portal/services/system_config.go
+++ b/portal/services/system_config.go
@@ -43,3 +43,12 @@ func CreateSystemConfig(tx *db.Session, cfg models.SystemCfg) (*models.SystemCfg
 
 	return &cfg, nil
 }
+
+func GetSystemConfigByName(tx *db.Session, name string) (*models.SystemCfg, e.Error) {
+	var cfg models.SystemCfg
+	if err := tx.Where("name = ?", name).First(&cfg); err != nil {
+		return nil, e.New(e.SystemConfigNotExist, err)
+	}
+
+	return &cfg, nil
+}

--- a/portal/services/system_config.go
+++ b/portal/services/system_config.go
@@ -8,6 +8,8 @@ import (
 	"cloudiac/portal/models"
 	"fmt"
 	"strconv"
+
+	"gorm.io/gorm"
 )
 
 func QuerySystemConfig(dbSess *db.Session) *db.Session {
@@ -47,8 +49,33 @@ func CreateSystemConfig(tx *db.Session, cfg models.SystemCfg) (*models.SystemCfg
 func GetSystemConfigByName(tx *db.Session, name string) (*models.SystemCfg, e.Error) {
 	var cfg models.SystemCfg
 	if err := tx.Where("name = ?", name).First(&cfg); err != nil {
-		return nil, e.New(e.SystemConfigNotExist, err)
+		if err == gorm.ErrRecordNotFound {
+			return nil, e.New(e.SystemConfigNotExist, err)
+		} else {
+			return nil, e.New(e.DBError, err)
+		}
 	}
 
 	return &cfg, nil
+}
+
+func UpsertRegistryAddr(tx *db.Session, val string) (*models.SystemCfg, e.Error) {
+	cfg, err := GetSystemConfigByName(tx, models.SysCfgNamRegistryAddr)
+	if err != nil {
+		if err.Err() == gorm.ErrRecordNotFound {
+			return CreateSystemConfig(tx, models.SystemCfg{
+				Name:  models.SysCfgNamRegistryAddr,
+				Value: val,
+			})
+		} else {
+			return nil, err
+		}
+	}
+
+	cfg.Value = val
+	if _, err := tx.Save(&cfg); err != nil {
+		return nil, e.New(e.DBError, err)
+	}
+
+	return cfg, nil
 }

--- a/portal/services/vcs.go
+++ b/portal/services/vcs.go
@@ -3,6 +3,7 @@
 package services
 
 import (
+	"cloudiac/portal/consts"
 	"cloudiac/portal/consts/e"
 	"cloudiac/portal/libs/db"
 	"cloudiac/portal/models"
@@ -36,7 +37,7 @@ func UpdateVcs(tx *db.Session, id models.Id, attrs models.Attrs) (vcs *models.Vc
 	return
 }
 
-func QueryVcs(orgId models.Id, status, q string, isShowdefaultVcs bool, query *db.Session) *db.Session {
+func QueryVcs(orgId models.Id, status, q string, isShowdefaultVcs, isShowRegistryVcs bool, query *db.Session) *db.Session {
 	query = query.Model(&models.Vcs{}).Where("org_id = ? or org_id = ''", orgId)
 	if status != "" {
 		query = query.Where("status = ?", status)
@@ -46,7 +47,10 @@ func QueryVcs(orgId models.Id, status, q string, isShowdefaultVcs bool, query *d
 		query = query.Where("name LIKE ?", qs)
 	}
 	if !isShowdefaultVcs {
-		query = query.Where("vcs_type != 'local'")
+		query = query.Where("vcs_type != ?", consts.GitTypeLocal)
+	}
+	if !isShowRegistryVcs {
+		query = query.Where("vcs_type != ?", consts.GitTypeRegistry)
 	}
 	return query.LazySelectAppend("id, org_id, project_id, name, status, vcs_type, address")
 }

--- a/portal/web/api/v1/handlers/system_config.go
+++ b/portal/web/api/v1/handlers/system_config.go
@@ -52,3 +52,15 @@ func (SystemConfig) Update(c *ctx.GinRequest) {
 	}
 	c.JSONResult(apps.UpdateSystemConfig(c.Service(), &form))
 }
+
+// CheckRegistryAddr 检查registry addr是否已配置
+// @Summary 检查registry addr是否已配置(先检查DB，再检查配置文件)
+// @Tags registry
+// @Accept  json
+// @Produce  json
+// @Security AuthToken
+// @Success 200 {object}  ctx.JSONResult{result=models.RegistryAddrCheckResp}
+// @Router /sys/registry/check [GET]
+func CheckRegistryAddr(c *ctx.GinRequest) {
+	c.JSONResult(apps.CheckRegistryAddr(c.Service()))
+}

--- a/portal/web/api/v1/handlers/system_config.go
+++ b/portal/web/api/v1/handlers/system_config.go
@@ -76,3 +76,19 @@ func CheckRegistryAddr(c *ctx.GinRequest) {
 func GetRegistryAddr(c *ctx.GinRequest) {
 	c.JSONResult(apps.GetRegistryAddr(c.Service()))
 }
+
+// UpsertRegistryAddr 更新或创建 registry addr 的配置
+// @Summary 更新或创建 registry addr 的配置
+// @Tags registry
+// @Accept  json
+// @Produce  json
+// @Security AuthToken
+// @Success 200 {object}  ctx.JSONResult{result=models.RegistryAddrResp}
+// @Router /system_config/registry/addr [POST]
+func UpsertRegistryAddr(c *ctx.GinRequest) {
+	form := forms.RegistryAddrForm{}
+	if err := c.Bind(&form); err != nil {
+		return
+	}
+	c.JSONResult(apps.UpsertRegistryAddr(c.Service(), &form))
+}

--- a/portal/web/api/v1/handlers/system_config.go
+++ b/portal/web/api/v1/handlers/system_config.go
@@ -53,18 +53,6 @@ func (SystemConfig) Update(c *ctx.GinRequest) {
 	c.JSONResult(apps.UpdateSystemConfig(c.Service(), &form))
 }
 
-// CheckRegistryAddr 检查registry addr是否已配置
-// @Summary 检查registry addr是否已配置(先检查DB，再检查配置文件)
-// @Tags registry
-// @Accept  json
-// @Produce  json
-// @Security AuthToken
-// @Success 200 {object}  ctx.JSONResult{result=models.RegistryAddrCheckResp}
-// @Router /system_config/registry/check [GET]
-func CheckRegistryAddr(c *ctx.GinRequest) {
-	c.JSONResult(apps.CheckRegistryAddr(c.Service()))
-}
-
 // GetRegistryAddr 获取 registry addr 的配置
 // @Summary 获取 registry addr 的配置
 // @Tags registry

--- a/portal/web/api/v1/handlers/system_config.go
+++ b/portal/web/api/v1/handlers/system_config.go
@@ -60,7 +60,19 @@ func (SystemConfig) Update(c *ctx.GinRequest) {
 // @Produce  json
 // @Security AuthToken
 // @Success 200 {object}  ctx.JSONResult{result=models.RegistryAddrCheckResp}
-// @Router /sys/registry/check [GET]
+// @Router /system_config/registry/check [GET]
 func CheckRegistryAddr(c *ctx.GinRequest) {
 	c.JSONResult(apps.CheckRegistryAddr(c.Service()))
+}
+
+// GetRegistryAddr 获取 registry addr 的配置
+// @Summary 获取 registry addr 的配置
+// @Tags registry
+// @Accept  json
+// @Produce  json
+// @Security AuthToken
+// @Success 200 {object}  ctx.JSONResult{result=models.RegistryAddrResp}
+// @Router /system_config/registry/addr [GET]
+func GetRegistryAddr(c *ctx.GinRequest) {
+	c.JSONResult(apps.GetRegistryAddr(c.Service()))
 }

--- a/portal/web/api/v1/route.go
+++ b/portal/web/api/v1/route.go
@@ -194,9 +194,9 @@ func Register(g *gin.RouterGroup) {
 	g.GET("/envs/:id/resources/graph/:resourceId", ac(), w(handlers.Env{}.ResourceGraphDetail))
 
 	// 系统设置
-	g.GET("/sys/registry/check") // 检查是否有registry地址的设置
-	g.GET("/sys/registry/addr")  // 获取registry地址的设置
-	g.POST("/sys/registry/addr") // 更新registry地址的设置
+	g.GET("/system_config/registry/check") // 检查是否有registry地址的设置
+	g.GET("/system_config/registry/addr")  // 获取registry地址的设置
+	g.POST("/system_config/registry/addr") // 更新registry地址的设置
 
 	// 任务管理
 	g.GET("/tasks", ac(), w(handlers.Task{}.Search))

--- a/portal/web/api/v1/route.go
+++ b/portal/web/api/v1/route.go
@@ -195,7 +195,7 @@ func Register(g *gin.RouterGroup) {
 
 	// 系统设置
 	g.GET("/system_config/registry/check", w(handlers.CheckRegistryAddr)) // 检查是否有registry地址的设置
-	g.GET("/system_config/registry/addr")                                 // 获取registry地址的设置
+	g.GET("/system_config/registry/addr", w(handlers.GetRegistryAddr))    // 获取registry地址的设置
 	g.POST("/system_config/registry/addr")                                // 更新registry地址的设置
 
 	// 任务管理

--- a/portal/web/api/v1/route.go
+++ b/portal/web/api/v1/route.go
@@ -194,7 +194,6 @@ func Register(g *gin.RouterGroup) {
 	g.GET("/envs/:id/resources/graph/:resourceId", ac(), w(handlers.Env{}.ResourceGraphDetail))
 
 	// 系统设置
-	g.GET("/system_config/registry/check", w(handlers.CheckRegistryAddr))  // 检查是否有registry地址的设置
 	g.GET("/system_config/registry/addr", w(handlers.GetRegistryAddr))     // 获取registry地址的设置
 	g.POST("/system_config/registry/addr", w(handlers.UpsertRegistryAddr)) // 更新registry地址的设置
 

--- a/portal/web/api/v1/route.go
+++ b/portal/web/api/v1/route.go
@@ -194,9 +194,9 @@ func Register(g *gin.RouterGroup) {
 	g.GET("/envs/:id/resources/graph/:resourceId", ac(), w(handlers.Env{}.ResourceGraphDetail))
 
 	// 系统设置
-	g.GET("/system_config/registry/check", w(handlers.CheckRegistryAddr)) // 检查是否有registry地址的设置
-	g.GET("/system_config/registry/addr", w(handlers.GetRegistryAddr))    // 获取registry地址的设置
-	g.POST("/system_config/registry/addr")                                // 更新registry地址的设置
+	g.GET("/system_config/registry/check", w(handlers.CheckRegistryAddr))  // 检查是否有registry地址的设置
+	g.GET("/system_config/registry/addr", w(handlers.GetRegistryAddr))     // 获取registry地址的设置
+	g.POST("/system_config/registry/addr", w(handlers.UpsertRegistryAddr)) // 更新registry地址的设置
 
 	// 任务管理
 	g.GET("/tasks", ac(), w(handlers.Task{}.Search))

--- a/portal/web/api/v1/route.go
+++ b/portal/web/api/v1/route.go
@@ -194,9 +194,9 @@ func Register(g *gin.RouterGroup) {
 	g.GET("/envs/:id/resources/graph/:resourceId", ac(), w(handlers.Env{}.ResourceGraphDetail))
 
 	// 系统设置
-	g.GET("/system_config/registry/check") // 检查是否有registry地址的设置
-	g.GET("/system_config/registry/addr")  // 获取registry地址的设置
-	g.POST("/system_config/registry/addr") // 更新registry地址的设置
+	g.GET("/system_config/registry/check", w(handlers.CheckRegistryAddr)) // 检查是否有registry地址的设置
+	g.GET("/system_config/registry/addr")                                 // 获取registry地址的设置
+	g.POST("/system_config/registry/addr")                                // 更新registry地址的设置
 
 	// 任务管理
 	g.GET("/tasks", ac(), w(handlers.Task{}.Search))

--- a/portal/web/api/v1/route.go
+++ b/portal/web/api/v1/route.go
@@ -193,6 +193,11 @@ func Register(g *gin.RouterGroup) {
 	g.GET("/envs/:id/resources/graph", ac(), w(handlers.Env{}.SearchResourcesGraph))
 	g.GET("/envs/:id/resources/graph/:resourceId", ac(), w(handlers.Env{}.ResourceGraphDetail))
 
+	// 系统设置
+	g.GET("/sys/registry/check") // 检查是否有registry地址的设置
+	g.GET("/sys/registry/addr")  // 获取registry地址的设置
+	g.POST("/sys/registry/addr") // 更新registry地址的设置
+
 	// 任务管理
 	g.GET("/tasks", ac(), w(handlers.Task{}.Search))
 	g.GET("/tasks/:id", ac(), w(handlers.Task{}.Detail))


### PR DESCRIPTION
包含内容如下：
1. 配置文件中增加 registryAddr 的配置
2. 判断registry addr是否存在的API
3. 获取registry addr的API
4. 更新或插入registry addr的API
5. 系统启动时初始化 registry vcs的信息到数据库
6. 检索vcs时默认不检索 registry vcs 的信息