### PR TITLE
fix: 合规中心->环境，列表展示的绑定策略组无返回的问题

### DIFF
--- a/portal/libs/page/page.go
+++ b/portal/libs/page/page.go
@@ -78,6 +78,10 @@ func (p *Paginator) getPage() *db.Session {
 	return sess
 }
 
+func (p *Paginator) GetPage() *db.Session {
+	return p.getPage()
+}
+
 func (p *Paginator) Scan(dest interface{}) error {
 	return p.getPage().Scan(dest)
 }


### PR DESCRIPTION
1. 该接口不需要返回 models.EnvDetail 结构里的字段，且使用 EnvDetail 做 Scan() 时会因为其中有 PolicyGroup 字段，同时 PolicyGroups 字段的 NewPolicyGroup 结构里又组合了 models.PolicyGroup，最终导致 gorm 认为我们是在做关联查询，自动查询了 model PolicyGroup，但因为 PolicyGroup 的字段类型为 []string 而非 struct，会报一个数据类型不匹配的错误。

2. envIds 未写入数据，导致没有查询到 policyGroups