### PR TITLE
fix 允许页面清空 registryaddr的值

### DIFF
--- a/portal/models/forms/system_config.go
+++ b/portal/models/forms/system_config.go
@@ -21,5 +21,5 @@ type SystemCfg struct {
 
 type RegistryAddrForm struct {
 	BaseForm
-	RegistryAddr string `form:"registryAddr" json:"registryAddr" binding:"required"`
+	RegistryAddr string `form:"registryAddr" json:"registryAddr"`
 }


### PR DESCRIPTION
去除设置 registryaddr的接口中， registryaddr不能为空的限制