### PR TITLE
fix: 任务 plan 失败后仍显示为执行中

### DIFF
--- a/portal/services/task.go
+++ b/portal/services/task.go
@@ -957,7 +957,9 @@ func fetchRunnerTaskStepLog(ctx context.Context, runnerId string, step *models.T
 
 		_, reader, err = wsConn.NextReader()
 		if err != nil {
-			if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+			if websocket.IsCloseError(err,
+				websocket.CloseNormalClosure,
+				websocket.CloseInternalServerErr) {
 				logger.Traceln(newReadMessageErr(err))
 				return nil
 			} else {

--- a/portal/task_manager/manager.go
+++ b/portal/task_manager/manager.go
@@ -163,24 +163,26 @@ func (m *TaskManager) start() {
 
 // 开始所有漂移检测任务
 func (m *TaskManager) beginCronDriftTask() {
-	logger := m.logger
+	logger := m.logger.WithField("func", "beginCronDriftTask")
 	cronDriftEnvs := make([]*models.Env, 0)
-	query := m.db.Where("status = ? and open_cron_drift = ? and next_drift_task_time <= ?", models.EnvStatusActive, true, time.Now())
+	query := m.db.Where("status = ? and open_cron_drift = ? and next_drift_task_time <= ?",
+		models.EnvStatusActive, true, time.Now())
 	if err := query.Model(&models.Env{}).Find(&cronDriftEnvs); err != nil {
 		logger.Error(err)
 		return
 	}
 	// 查询出来所有需要开启偏移检测的环境任务，并且创建
 	for _, env := range cronDriftEnvs {
+		logger = logger.WithField("envId", env.Id)
 		task, err := services.GetTaskById(m.db, env.LastTaskId)
 		if err != nil {
-			logger.Errorf("create cronDriftTask failed, error: %v", err) //nolint
+			logger.Errorf("get task by id error: %v", err) //nolint
 			continue
 		}
 		// 先查询这个环境有没有排队中的偏移检测任务了, 有就不创建了
 		existCronPendingTask, err := services.ListPendingCronTask(m.db, env.Id)
 		if err != nil {
-			logger.Errorf("create cronDriftTask failed, error: %v", err) //nolint
+			logger.Errorf("list pending cron task error: %v", err) //nolint
 			continue
 		}
 		// 如果查询出来有排队或执行中的漂移检测任务，则本次跳过
@@ -190,14 +192,14 @@ func (m *TaskManager) beginCronDriftTask() {
 		// 这里每次都去解析env表保存的最新的cron 表达式
 		envCronTaskType, err := apps.GetCronTaskTypeAndCheckParam(env.CronDriftExpress, env.AutoRepairDrift, env.OpenCronDrift)
 		if err != nil {
-			logger.Errorf("create cronDriftTask failed, error: %v", err) //nolint
+			logger.Errorf("get cron task type error: %v", err) //nolint
 			continue
 		}
 		if envCronTaskType != "" {
 			attrs := models.Attrs{}
 			nextTime, err := apps.ParseCronpress(env.CronDriftExpress)
 			if err != nil {
-				logger.Errorf("create cronDriftTask failed, error: %v", err) //nolint
+				logger.Errorf("parse cron express error: %v", err) //nolint
 				continue
 			}
 			task.Type = envCronTaskType
@@ -209,14 +211,14 @@ func (m *TaskManager) beginCronDriftTask() {
 			}
 			_, err = services.CloneNewDriftTask(m.db, *task, env)
 			if err != nil {
-				logger.Errorf("create cronDriftTask failed, error: %v", err) //nolint
+				logger.Errorf("clone drift task error: %v", err) //nolint
 				continue
 			}
 
 			attrs["nextDriftTaskTime"] = nextTime
 			_, err = services.UpdateEnv(m.db, env.Id, attrs)
 			if err != nil {
-				logger.Errorf("create cronDriftTask failed, error: %v", err) //nolint
+				logger.Errorf("update env, error: %v", err) //nolint
 				continue
 			}
 		}
@@ -248,7 +250,7 @@ func (m *TaskManager) recoverTask(ctx context.Context) error {
 		tasks[scanTasksLen+idx] = deployTasks[idx]
 	}
 
-	logger.Infof("find '%d' running tasks", len(tasks))
+	logger.Infof("find running tasks: %d", len(tasks))
 	for _, task := range tasks {
 		select {
 		case <-ctx.Done():
@@ -460,14 +462,16 @@ func (m *TaskManager) doRunTask(ctx context.Context, task *models.Task) (startEr
 	}
 
 	if task.IsEffectTask() {
-		if _, er := m.db.Model(&models.Env{}).Where("id = ?", task.EnvId). //nolint
+		if _, er := m.db.Model(&models.Env{}).
+			Where("id = ?", task.EnvId). //nolint
 			Update(&models.Env{LastTaskId: task.Id}); er != nil {
 			logger.Errorf("update env lastTaskId: %v", er)
 			return
 		}
 		scanTask, _ := services.GetMirrorScanTask(m.db, task.Id)
 		if scanTask != nil {
-			if _, er := m.db.Model(&models.Env{}).Where("id = ?", task.EnvId). //nolint
+			if _, er := m.db.Model(&models.Env{}).
+				Where("id = ?", task.EnvId). //nolint
 				Update(&models.Env{LastScanTaskId: task.Id}); er != nil {
 				logger.Errorf("update env lastTaskId: %v", er)
 				return
@@ -997,7 +1001,8 @@ func (m *TaskManager) processAutoDestroy() error {
 				return nil
 			}
 
-			if _, err := tx.Model(&models.Env{}).Where("id = ?", env.Id). //nolint
+			if _, err := tx.Model(&models.Env{}).
+				Where("id = ?", env.Id). //nolint
 				Update(&models.Env{AutoDestroyTaskId: task.Id}); err != nil {
 				_ = tx.Rollback()
 				logger.Errorf("update env error: %v", err)
@@ -1029,7 +1034,6 @@ func (m *TaskManager) processAutoDestroy() error {
 //nolint:cyclop
 func (m *TaskManager) doRunScanTask(ctx context.Context, task *models.ScanTask) (startErr error) {
 	logger := m.logger.WithField("taskId", task.Id)
-
 
 	changeTaskStatus := func(status, message string) error {
 		if er := services.ChangeScanTaskStatus(m.db, task, status, message); er != nil {
@@ -1064,7 +1068,8 @@ func (m *TaskManager) doRunScanTask(ctx context.Context, task *models.ScanTask) 
 			return
 		}
 	} else if task.Type == common.TaskTypeTplScan || (task.Type == common.TaskTypeScan && task.EnvId == "") { // 模板扫描
-		if _, err := m.db.Where("id = ?", task.TplId). //nolint
+		if _, err := m.db.
+			Where("id = ?", task.TplId). //nolint
 			Update(&models.Template{LastScanTaskId: task.Id}); err != nil {
 			logger.Errorf("update template lastScanTaskId: %v", err)
 			return

--- a/portal/task_manager/task.go
+++ b/portal/task_manager/task.go
@@ -92,7 +92,7 @@ func WaitTaskStep(ctx context.Context, sess *db.Session, task *models.Task, step
 	taskDeadline := time.Time(*step.StartAt).Add(time.Duration(task.StepTimeout*2) * time.Second)
 
 	// 当前版本实现中需要 portal 主动连接到 runner 获取状态
-	err = utils.RetryFunc(10, time.Second*10, func(retryN int) (retry bool, er error) {
+	err = utils.RetryFunc(10, time.Second*5, func(retryN int) (retry bool, er error) {
 		stepResult, er = pullTaskStepStatus(ctx, task, step, taskDeadline)
 		if er != nil {
 			logger.Errorf("pull task status error: %v, retry(%d)", er, retryN)
@@ -230,7 +230,9 @@ func pullTaskStepStatus(ctx context.Context, task models.Tasker, step *models.Ta
 		for {
 			message := runner.TaskStatusMessage{}
 			if err := wsConn.ReadJSON(&message); err != nil {
-				if websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+				if websocket.IsCloseError(err,
+					websocket.CloseNormalClosure,
+					websocket.CloseInternalServerErr) {
 					logger.Traceln(newReadMessageErr(err))
 				} else {
 					logger.Warnln(newReadMessageErr(err))
@@ -357,7 +359,7 @@ func WaitScanTaskStep(ctx context.Context, sess *db.Session, task *models.ScanTa
 	taskDeadline := time.Time(*step.StartAt).Add(time.Duration(task.StepTimeout*2) * time.Second)
 
 	// 当前版本实现中需要 portal 主动连接到 runner 获取状态
-	err = utils.RetryFunc(10, time.Second*10, func(retryN int) (retry bool, er error) {
+	err = utils.RetryFunc(10, time.Second*5, func(retryN int) (retry bool, er error) {
 		stepResult, er = pullTaskStepStatus(ctx, task, step, taskDeadline)
 		if er != nil {
 			logger.Errorf("pull task status error: %v, retry(%d)", er, retryN)

--- a/runner/command.go
+++ b/runner/command.go
@@ -241,7 +241,7 @@ func (Executor) WaitCommand(ctx context.Context, containerId string, execId stri
 
 		inspect, err := cli.ContainerExecInspect(ctx, execId)
 		if err != nil {
-			if err == context.DeadlineExceeded {
+			if errors.Is(err, context.DeadlineExceeded) {
 				return execInfo, err
 			}
 			return execInfo, errors.Wrap(err, "container exec inspect")
@@ -259,7 +259,7 @@ func (exec Executor) WaitCommandWithDeadline(ctx context.Context, containerId st
 
 	logger.Debugf("wait exec %s, deadline: %s", execId, deadline.Format(time.RFC3339))
 	if execInfo, err = exec.WaitCommand(ctx, containerId, execId); err != nil {
-		if err == context.DeadlineExceeded {
+		if errors.Is(err, context.DeadlineExceeded) {
 			// logger.Infof("task %s/step%s: %v", exec..TaskId, t.req.Step, err)
 			if err := (Executor{}).StopCommand(execId); err != nil {
 				logger.WithField("cid", execInfo.ContainerID).Errorf("stop command error: %v", err)

--- a/runner/committed_task.go
+++ b/runner/committed_task.go
@@ -132,6 +132,7 @@ func (task *StartedTask) readContainerInfo() (info types.ContainerExecInspect, e
 
 // Wait 等待任务结束返回退出码，若超时返回 error=context.DeadlineExceeded
 // 如果等待到任务结束则会将容器状态信息写入到文件，并判断是否需要暂停容器
+// 注意：该函数可能会被多个请求源同时调用，不要在该函数中添加不可重复执行的逻辑。
 func (task *StartedTask) Wait(ctx context.Context) (int64, error) {
 	logger := logger.WithField("taskId", task.TaskId).
 		WithField("containerId", utils.ShortContainerId(task.ContainerId))
@@ -150,9 +151,9 @@ func (task *StartedTask) Wait(ctx context.Context) (int64, error) {
 	)
 	if task.StartedAt != nil && task.Timeout > 0 {
 		deadline := task.StartedAt.Add(time.Duration(task.Timeout) * time.Second)
-		info, err = Executor{}.WaitCommandWithDeadline(ctx, task.ExecId, deadline)
+		info, err = Executor{}.WaitCommandWithDeadline(ctx, task.ContainerId, task.ExecId, deadline)
 	} else {
-		info, err = Executor{}.WaitCommand(ctx, task.ExecId)
+		info, err = Executor{}.WaitCommand(ctx, task.ContainerId, task.ExecId)
 	}
 
 	if err != nil {
@@ -170,8 +171,10 @@ func (task *StartedTask) Wait(ctx context.Context) (int64, error) {
 		}
 
 		// 暂停容器
+		// 当有多个请求源同时调用该函数时，容器暂停操作可能被调用多次，这是允许的，多次调用 Pause() 不会报错。
+		// 但要保证调用 Pause() 是及时的，避免下一步骤己经启动了，前一步骤触发的 Pause 操作才被调用，这会导致容器被异常暂停。
 		if task.PauseOnFinish {
-			logger.Debugf("pause container %s", info.ContainerID)
+			logger.Debugf("pause container %s", utils.ShortContainerId(info.ContainerID))
 			if err := (Executor{}).Pause(info.ContainerID); err != nil {
 				logger.Warn(err)
 			}

--- a/runner/docker_client.go
+++ b/runner/docker_client.go
@@ -1,3 +1,5 @@
+// Copyright (c) 2015-2022 CloudJ Technology Co., Ltd.
+
 package runner
 
 import (

--- a/runner/docker_client.go
+++ b/runner/docker_client.go
@@ -1,0 +1,40 @@
+package runner
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/docker/docker/client"
+	"github.com/pkg/errors"
+)
+
+var (
+	defaultDockerClient         *client.Client
+	defaultDockerClientInitOnce sync.Once
+)
+
+func DockerClient() (*client.Client, error) {
+	return dockerClient()
+}
+
+func dockerClient() (*client.Client, error) {
+	defaultDockerClientInitOnce.Do(func() {
+		var err error
+		defaultDockerClient, err = initDockerClient()
+		if err != nil {
+			panic(fmt.Errorf("init docker client error: %v", err))
+		}
+	})
+	return defaultDockerClient, nil
+}
+
+func initDockerClient() (*client.Client, error) {
+	cli, err := client.NewClientWithOpts(
+		client.FromEnv,
+		client.WithAPIVersionNegotiation(),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "create docker client")
+	}
+	return cli, nil
+}

--- a/runner/task.go
+++ b/runner/task.go
@@ -9,7 +9,6 @@ import (
 	"cloudiac/portal/consts"
 	"cloudiac/utils"
 	"cloudiac/utils/logs"
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -192,13 +191,6 @@ func (t *Task) runStep() (err error) {
 	}
 
 	now := time.Now()
-
-	// 后台协程监控到命令结束就会暂停容器，
-	// 同时 task.Wait() 函数也会在任务结束后暂停容器，两边同时处理保证容器被暂停
-	if t.req.PauseTask {
-		go t.waitCommandThenPauseContainer(execId)
-	}
-
 	infoJson := utils.MustJSON(StartedTask{
 		EnvId:         t.req.Env.Id,
 		TaskId:        t.req.TaskId,
@@ -218,20 +210,6 @@ func (t *Task) runStep() (err error) {
 		return err
 	}
 	return nil
-}
-
-func (t *Task) waitCommandThenPauseContainer(execId string) {
-	_, err := (Executor{}).WaitCommand(context.Background(), execId)
-	if err != nil {
-		logger.Debugf("container %s: %v", t.req.ContainerId, err)
-		return
-	}
-
-	logger.Debugf("pause container %s", t.req.ContainerId)
-	if err := (&Executor{}).Pause(t.req.ContainerId); err != nil {
-		logger.Debugf("container %s: %v", t.req.ContainerId, err)
-		return
-	}
 }
 
 func (t *Task) decryptVariables(vars map[string]string) error {


### PR DESCRIPTION
因为暂停容器的逻辑有多处，且暂停容器的调用是定时检查，
暂停操作调用不及时，可能出现后续步骤己启动执行，
但前续步骤的容器暂停逻辑才被调用，导致容器被异常暂停。

解决方案：
1. 我们对容器暂停功能不是强需求，现在只在 task.Wait() 函数中执行容器暂停，该调用会在任务结束后及时触发。
2. 在等待容器中进程结束时判断容器是否被暂停，如果被暂停则报错，及时反馈，避免一直不退出。

同时该 commit 还对 docker client 的创建进行了优化，重用了全局的 defautlDockerClient，避免重复创建连接占用 fd。