### PR TITLE
基于 tag 的 runner 匹配

### DIFF
--- a/cmds/portal/main.go
+++ b/cmds/portal/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 
 	"cloudiac/cmds/common"
+	iac_common "cloudiac/common"
 	"cloudiac/configs"
 	"cloudiac/portal/consts"
 	"cloudiac/portal/consts/e"
@@ -74,7 +75,7 @@ func main() {
 	}
 
 	// 注册到 consul
-	common.ReRegisterService(opt.ReRegister, "IaC-Portal")
+	common.ReRegisterService(opt.ReRegister, iac_common.IacPortalServiceName)
 
 	// 启动后台 worker
 	go task_manager.Start(configs.Get().Consul.ServiceID)

--- a/cmds/runner/main.go
+++ b/cmds/runner/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pkg/errors"
 
 	"cloudiac/cmds/common"
+	iac_common "cloudiac/common"
 	"cloudiac/configs"
 	"cloudiac/utils/logs"
 )
@@ -52,7 +53,7 @@ func main() {
 	runnerConfJson, _ := json.Marshal(configs.Get().Runner)
 	logs.Get().Infof("runner configs: %s", runnerConfJson)
 
-	common.ReRegisterService(opt.ReRegister, "CT-Runner")
+	common.ReRegisterService(opt.ReRegister, iac_common.RunnerServiceName)
 	StartServer()
 }
 

--- a/common/consts.go
+++ b/common/consts.go
@@ -109,6 +109,9 @@ const (
 
 	PolicySuppressTypeSource = "source"
 	PolicySuppressTypePolicy = "policy"
+
+	RunnerServiceName    = "CT-Runner"
+	IacPortalServiceName = "IaC-Portal"
 )
 
 var (

--- a/portal/apps/env.go
+++ b/portal/apps/env.go
@@ -163,7 +163,7 @@ func getRunnerId(runnerTags []string, runnerId string) (string, e.Error) {
 	}
 
 	// id不存在，使用tags 匹配
-	if runnerTags != nil && len(runnerTags) > 0 {
+	if len(runnerTags) > 0 {
 		return services.GetRunnerByTags(runnerTags)
 	}
 
@@ -867,6 +867,17 @@ func envTplCheck(tx *db.Session, orgId, tplId models.Id, lg logs.Logger) (*model
 	return tpl, nil
 }
 
+func setEnvRunnerId(env *models.Env, form *forms.DeployEnvForm) {
+	runnerId := ""
+	if form.HasKey("runnerId") {
+		runnerId = form.RunnerId
+	} else if form.HasKey("runnerTags") {
+		env.RunnerTags = strings.Join(form.RunnerTags, ",")
+		runnerId, _ = getRunnerId(form.RunnerTags, form.RunnerId)
+	}
+	env.RunnerId = runnerId
+}
+
 func setEnvByForm(env *models.Env, form *forms.DeployEnvForm) {
 	if form.HasKey("name") {
 		env.Name = form.Name
@@ -883,14 +894,7 @@ func setEnvByForm(env *models.Env, form *forms.DeployEnvForm) {
 		env.KeyId = form.KeyId
 	}
 
-	runnerId := ""
-	if form.HasKey("runnerId") {
-		runnerId = form.RunnerId
-	} else if form.HasKey("runnerTags") {
-		env.RunnerTags = strings.Join(form.RunnerTags, ",")
-		runnerId, _ = getRunnerId(form.RunnerTags, form.RunnerId)
-	}
-	env.RunnerId = runnerId
+	setEnvRunnerId(env, form)
 
 	if form.HasKey("timeout") {
 		env.Timeout = form.Timeout

--- a/portal/apps/env.go
+++ b/portal/apps/env.go
@@ -912,6 +912,10 @@ func setEnvByForm(env *models.Env, form *forms.DeployEnvForm) {
 		env.PolicyEnable = form.PolicyEnable
 	}
 
+	setEnvRunnerInfoByForm(env, form)
+}
+
+func setEnvRunnerInfoByForm(env *models.Env, form *forms.DeployEnvForm) {
 	if form.HasKey("runnerId") {
 		env.RunnerId = form.RunnerId
 	}

--- a/portal/apps/env.go
+++ b/portal/apps/env.go
@@ -310,11 +310,12 @@ func CreateEnv(c *ctx.ServiceContext, form *forms.CreateEnvForm) (*models.EnvDet
 		CreatorId: c.UserId,
 		TplId:     form.TplId,
 
-		Name:     form.Name,
-		RunnerId: runnerId,
-		Status:   models.EnvStatusInactive,
-		OneTime:  form.OneTime,
-		Timeout:  form.Timeout,
+		Name:       form.Name,
+		RunnerId:   runnerId,
+		RunnerTags: strings.Join(form.RunnerTags, ","),
+		Status:     models.EnvStatusInactive,
+		OneTime:    form.OneTime,
+		Timeout:    form.Timeout,
 
 		// 模板参数
 		TfVarsFile:   form.TfVarsFile,

--- a/portal/apps/env.go
+++ b/portal/apps/env.go
@@ -481,6 +481,8 @@ func SearchEnv(c *ctx.ServiceContext, form *forms.SearchEnvForm) (interface{}, e
 		env.MergeTaskStatus()
 		PopulateLastTask(c.DB(), env)
 		env.PolicyStatus = models.PolicyStatusConversion(env.PolicyStatus, env.PolicyEnable)
+		// runner tags 数组形式返回
+		env.RunnerTagsArr = strings.Split(env.Env.RunnerTags, ",")
 	}
 
 	return page.PageResp{
@@ -801,6 +803,8 @@ func EnvDetail(c *ctx.ServiceContext, form forms.DetailEnvForm) (*models.EnvDeta
 	}
 	envDetail.PolicyStatus = models.PolicyStatusConversion(envDetail.PolicyStatus, envDetail.PolicyEnable)
 
+	// runner tags 数组形式返回
+	envDetail.RunnerTagsArr = strings.Split(envDetail.Env.RunnerTags, ",")
 	return envDetail, nil
 }
 

--- a/portal/apps/env.go
+++ b/portal/apps/env.go
@@ -157,15 +157,18 @@ func setDefaultValueFromTpl(form *forms.CreateEnvForm, tpl *models.Template, des
 }
 
 func getRunnerId(form *forms.CreateEnvForm) (string, e.Error) {
-	var runnerId string = form.RunnerId
-	if runnerId == "" {
-		rId, err := services.GetDefaultRunner()
-		if err != nil {
-			return "", err
-		}
-		runnerId = rId
+	// tags 匹配
+	if form.RunnerTags != nil && len(form.RunnerTags) > 0 {
+		return services.GetRunnerByTags(form.RunnerTags)
 	}
-	return runnerId, nil
+
+	// id 匹配
+	if form.RunnerId != "" {
+		return form.RunnerId, nil
+	}
+
+	// 默认runner
+	return services.GetDefaultRunner()
 }
 
 func createEnvToDB(tx *db.Session, c *ctx.ServiceContext, form *forms.CreateEnvForm, envModel models.Env) (*models.Env, e.Error) {

--- a/portal/apps/system_status.go
+++ b/portal/apps/system_status.go
@@ -28,6 +28,10 @@ type SystemStatusResp struct {
 	//Warn     uint64 `json:"warn" form:"warn" `
 }
 
+type RunnerTagsResp struct {
+	Tags []string `json:"tags"`
+}
+
 func SystemStatusSearch() (interface{}, e.Error) {
 	resp := make([]*SystemStatusResp, 0)
 	serviceResp := make(map[string]*SystemStatusResp)
@@ -100,4 +104,15 @@ func ConsulTagUpdate(c *ctx.ServiceContext, form forms.ConsulTagUpdateForm) (int
 		return nil, err
 	}
 	return nil, nil
+}
+
+func RunnerTags() (interface{}, e.Error) {
+	tags, err := services.SystemRunnerTags()
+	if err != nil {
+		return nil, err
+	}
+
+	return &RunnerTagsResp{
+		Tags: tags,
+	}, nil
 }

--- a/portal/apps/system_status.go
+++ b/portal/apps/system_status.go
@@ -4,8 +4,11 @@ package apps
 
 import (
 	"cloudiac/portal/consts/e"
+	"cloudiac/portal/libs/ctx"
 	"cloudiac/portal/models/forms"
 	"cloudiac/portal/services"
+	"fmt"
+	"net/http"
 )
 
 type SystemStatusResp struct {
@@ -77,7 +80,12 @@ func RunnerSearch() (interface{}, e.Error) {
 	return services.RunnerSearch()
 }
 
-func ConsulTagUpdate(form forms.ConsulTagUpdateForm) (interface{}, e.Error) {
+func ConsulTagUpdate(c *ctx.ServiceContext, form forms.ConsulTagUpdateForm) (interface{}, e.Error) {
+	// 检查是否有修改tags的权限
+	if !c.IsSuperAdmin {
+		return nil, e.New(e.PermissionDeny, fmt.Errorf("super admin required"), http.StatusForbidden)
+	}
+
 	//将修改后的tag存到consul中
 	if err := services.ConsulKVSave(form.ServiceId, form.Tags); err != nil {
 		return nil, err

--- a/portal/models/env.go
+++ b/portal/models/env.go
@@ -50,9 +50,10 @@ type Env struct {
 	Playbook     string `json:"playbook" gorm:"default:''"`     // Ansible playbook 入口文件路径
 
 	// 任务相关参数，获取详情的时候，如果有 last_task_id 则返回 last_task_id 相关参数
-	RunnerId string `json:"runnerId" gorm:"size:32;not null"`   //部署通道ID
-	Revision string `json:"revision" gorm:"size:64;default:''"` // Vcs仓库分支/标签
-	KeyId    Id     `json:"keyId" gorm:"size:32"`               // 部署密钥ID
+	RunnerId   string `json:"runnerId" gorm:"size:32"`            //部署通道ID
+	RunnerTags string `json:"runnerTags" gorm:"size:256"`         //部署通道Tags,逗号分割
+	Revision   string `json:"revision" gorm:"size:64;default:''"` // Vcs仓库分支/标签
+	KeyId      Id     `json:"keyId" gorm:"size:32"`               // 部署密钥ID
 
 	LastTaskId    Id `json:"lastTaskId" gorm:"size:32"`    // 最后一次部署或销毁任务的 id(plan 任务不记录)
 	LastResTaskId Id `json:"lastResTaskId" gorm:"size:32"` // 最后一次进行了资源列表统计的部署任务的 id

--- a/portal/models/env.go
+++ b/portal/models/env.go
@@ -143,8 +143,8 @@ type EnvDetail struct {
 	// gorm 解析该结构体的 PolicyGroup 字段时会将其理解为 PolicyGroup model 的关联字段，
 	// 但解析类型却发现是一个 []string， 而非 []struct{}，导致报错  "[error] unsupported data type: &[]"
 	// (这个报错只在 gorm 日志中打印，db.Error 无错误)。
-	PolicyGroup   []string `json:"policyGroup" gorm:"-"` // 环境相关合规策略组
-	RunnerTagsArr []string `json:"runnerTagsArr"`        // runner tags array
+	PolicyGroup   []string `json:"policyGroup" gorm:"-"`   // 环境相关合规策略组
+	RunnerTagsArr []string `json:"runnerTagsArr" gorm:"-"` // runner tags array
 }
 
 func (c *EnvDetail) UpdateEnvPolicyStatus() {

--- a/portal/models/env.go
+++ b/portal/models/env.go
@@ -143,7 +143,8 @@ type EnvDetail struct {
 	// gorm 解析该结构体的 PolicyGroup 字段时会将其理解为 PolicyGroup model 的关联字段，
 	// 但解析类型却发现是一个 []string， 而非 []struct{}，导致报错  "[error] unsupported data type: &[]"
 	// (这个报错只在 gorm 日志中打印，db.Error 无错误)。
-	PolicyGroup []string `json:"policyGroup" gorm:"-"` // 环境相关合规策略组
+	PolicyGroup   []string `json:"policyGroup" gorm:"-"` // 环境相关合规策略组
+	RunnerTagsArr []string `json:"runnerTagsArr"`        // runner tags array
 }
 
 func (c *EnvDetail) UpdateEnvPolicyStatus() {

--- a/portal/models/forms/env.go
+++ b/portal/models/forms/env.go
@@ -108,11 +108,12 @@ type DeployEnvForm struct {
 	AutoApproval    bool     `form:"autoApproval" json:"autoApproval"  binding:"" enums:"true,false"` // 是否自动审批
 	StopOnViolation bool     `form:"stopOnViolation" json:"stopOnViolation" enums:"true,false"`       // 合规不通过是否中止任务
 
-	TaskType string `form:"taskType" json:"taskType" binding:"required" enums:"plan,apply,destroy"` // 环境创建后触发的任务步骤，plan计划,apply部署,destroy销毁资源
-	Targets  string `form:"targets" json:"targets" binding:""`                                      // Terraform target 参数列表
-	RunnerId string `form:"runnerId" json:"runnerId" binding:""`                                    // 环境默认部署通道
-	Revision string `form:"revision" json:"revision" binding:""`                                    // 分支/标签
-	Timeout  int    `form:"timeout" json:"timeout" binding:""`                                      // 部署超时时间（单位：秒）
+	TaskType   string   `form:"taskType" json:"taskType" binding:"required" enums:"plan,apply,destroy"` // 环境创建后触发的任务步骤，plan计划,apply部署,destroy销毁资源
+	Targets    string   `form:"targets" json:"targets" binding:""`                                      // Terraform target 参数列表
+	RunnerId   string   `form:"runnerId" json:"runnerId" binding:""`                                    // 环境默认部署通道
+	RunnerTags []string `form:"runnerTags" json:"runnerTags" binding:""`                                // 环境默认部署通道Tags
+	Revision   string   `form:"revision" json:"revision" binding:""`                                    // 分支/标签
+	Timeout    int      `form:"timeout" json:"timeout" binding:""`                                      // 部署超时时间（单位：秒）
 
 	RetryNumber int  `form:"retryNumber" json:"retryNumber" binding:""` // 重试总次数
 	RetryDelay  int  `form:"retryDelay" json:"retryDelay" binding:""`   // 重试时间间隔

--- a/portal/models/forms/env.go
+++ b/portal/models/forms/env.go
@@ -20,13 +20,14 @@ type CreateEnvForm struct {
 	OneTime  bool      `form:"oneTime" json:"oneTime" binding:""`                // 一次性环境标识
 	Triggers []string  `form:"triggers" json:"triggers" binding:""`              // 启用触发器，触发器：commit（每次推送自动部署），prmr（提交PR/MR的时候自动执行plan）
 
-	AutoApproval    bool   `form:"autoApproval" json:"autoApproval"  binding:"" enums:"true,false"` // 是否自动审批
-	StopOnViolation bool   `form:"stopOnViolation" json:"stopOnViolation" enums:"true,false"`       // 合规不通过是否中止任务
-	TaskType        string `form:"taskType" json:"taskType" binding:"required" enums:"plan,apply"`  // 环境创建后触发的任务步骤，plan计划,apply部署
-	Targets         string `form:"targets" json:"targets" binding:""`                               // Terraform target 参数列表，多个参数用 , 进行分隔
-	RunnerId        string `form:"runnerId" json:"runnerId" binding:""`                             // 环境默认部署通道
-	Revision        string `form:"revision" json:"revision" binding:""`                             // 分支/标签
-	Timeout         int    `form:"timeout" json:"timeout" binding:""`                               // 部署超时时间（单位：秒）
+	AutoApproval    bool     `form:"autoApproval" json:"autoApproval"  binding:"" enums:"true,false"` // 是否自动审批
+	StopOnViolation bool     `form:"stopOnViolation" json:"stopOnViolation" enums:"true,false"`       // 合规不通过是否中止任务
+	TaskType        string   `form:"taskType" json:"taskType" binding:"required" enums:"plan,apply"`  // 环境创建后触发的任务步骤，plan计划,apply部署
+	Targets         string   `form:"targets" json:"targets" binding:""`                               // Terraform target 参数列表，多个参数用 , 进行分隔
+	RunnerId        string   `form:"runnerId" json:"runnerId" binding:""`                             // 环境默认部署通道
+	RunnerTags      []string `form:"runnerTags" json:"runnerTags" binding:""`                         // 环境默认部署通道tags
+	Revision        string   `form:"revision" json:"revision" binding:""`                             // 分支/标签
+	Timeout         int      `form:"timeout" json:"timeout" binding:""`                               // 部署超时时间（单位：秒）
 
 	Variables []Variable `form:"variables" json:"variables" binding:""` // 自定义变量列表，该变量列表会覆盖现有的变量
 

--- a/portal/services/env.go
+++ b/portal/services/env.go
@@ -11,6 +11,7 @@ import (
 	"cloudiac/utils"
 	"cloudiac/utils/logs"
 	"fmt"
+	"math/rand"
 	"time"
 
 	"github.com/hashicorp/consul/api"
@@ -258,7 +259,8 @@ func GetRunnerByTags(tags []string) (string, e.Error) {
 	}
 
 	if len(validRunners) > 0 {
-		return validRunners[0].ID, nil
+		rand.Seed(time.Now().Unix())
+		return validRunners[rand.Intn(len(validRunners))].ID, nil
 	}
 
 	return "", e.New(e.ConsulConnError, fmt.Errorf("runner list with tags is null"))

--- a/portal/services/env.go
+++ b/portal/services/env.go
@@ -260,7 +260,7 @@ func GetRunnerByTags(tags []string) (string, e.Error) {
 
 	if len(validRunners) > 0 {
 		rand.Seed(time.Now().Unix())
-		return validRunners[rand.Intn(len(validRunners))].ID, nil
+		return validRunners[rand.Intn(len(validRunners))].ID, nil //nolint:gosec
 	}
 
 	return "", e.New(e.ConsulConnError, fmt.Errorf("runner list with tags is null"))

--- a/portal/services/env.go
+++ b/portal/services/env.go
@@ -8,9 +8,12 @@ import (
 	"cloudiac/portal/libs/db"
 	"cloudiac/portal/models"
 	"cloudiac/portal/models/forms"
+	"cloudiac/utils"
 	"cloudiac/utils/logs"
 	"fmt"
 	"time"
+
+	"github.com/hashicorp/consul/api"
 )
 
 func GetEnv(sess *db.Session, id models.Id) (*models.Env, error) {
@@ -241,6 +244,26 @@ func GetDefaultRunner() (string, e.Error) {
 	return "", e.New(e.ConsulConnError, fmt.Errorf("runner list is null"))
 }
 
+func GetRunnerByTags(tags []string) (string, e.Error) {
+	runners, err := RunnerSearch()
+	if err != nil {
+		return "", err
+	}
+
+	validRunners := make([]*api.AgentService, 0)
+	for _, runner := range runners {
+		if utils.ListContains(runner.Tags, tags) {
+			validRunners = append(validRunners, runner)
+		}
+	}
+
+	if len(validRunners) > 0 {
+		return validRunners[0].ID, nil
+	}
+
+	return "", e.New(e.ConsulConnError, fmt.Errorf("runner list with tags is null"))
+}
+
 func isVarNewValid(v forms.SampleVariables, value models.Variable) bool {
 	// 对于第三方调用api创建的环境来说，当前作用域是无变量的，sampleVariables中的变量一种是继承性下来的、另一种是新建的
 	// 这里需要判断变量如果修改了就在当前作用域创建一个变量
@@ -274,16 +297,16 @@ func GetSampleValidVariables(tx *db.Session, orgId, projectId, tplId, envId mode
 	for _, v := range sampleVariables {
 		// 如果vars为空，则需要将sampleVariables所有的变量理解为新增变量
 		if len(vars) == 0 {
-			resp = varNewAppend(resp,v.Name,v.Value,consts.VarTypeEnv)
+			resp = varNewAppend(resp, v.Name, v.Value, consts.VarTypeEnv)
 			continue
 		}
 
 		for key, value := range vars {
 			if !isVarNewValid(v, value) {
-				resp = varNewAppend(resp,vars[key].Name,v.Value, vars[key].Type)
+				resp = varNewAppend(resp, vars[key].Name, v.Value, vars[key].Type)
 			} else {
 				// 这部分变量是新增的 需要新建
-				resp = varNewAppend(resp,v.Name,v.Value,consts.VarTypeEnv)
+				resp = varNewAppend(resp, v.Name, v.Value, consts.VarTypeEnv)
 			}
 		}
 	}

--- a/portal/services/system_status.go
+++ b/portal/services/system_status.go
@@ -77,7 +77,7 @@ func SystemRunnerTags() ([]string, e.Error) {
 		tags = append(tags, info.Tags...)
 	}
 
-	return utils.UniqStrings(tags), nil
+	return utils.RemoveDuplicateElement(tags), nil
 }
 
 func ConsulKVSearch(key string) (interface{}, e.Error) {

--- a/portal/web/api/v1/handlers/system_status.go
+++ b/portal/web/api/v1/handlers/system_status.go
@@ -56,3 +56,16 @@ func ConsulTagUpdate(c *ctx.GinRequest) {
 	}
 	c.JSONResult(apps.ConsulTagUpdate(c.Service(), form))
 }
+
+// RunnerTags 查询runner tags列表
+// @Summary 查询runner tags列表
+// @Description 查询runner tags列表
+// @Tags runner
+// @Accept  json
+// @Produce  json
+// @Security AuthToken
+// @Success 200
+// @Router /runners/tags [get]
+func RunnerTags(c *ctx.GinRequest) {
+	c.JSONResult(apps.RunnerTags())
+}

--- a/portal/web/api/v1/handlers/system_status.go
+++ b/portal/web/api/v1/handlers/system_status.go
@@ -54,5 +54,5 @@ func ConsulTagUpdate(c *ctx.GinRequest) {
 	if err := c.Bind(&form); err != nil {
 		return
 	}
-	c.JSONResult(apps.ConsulTagUpdate(form))
+	c.JSONResult(apps.ConsulTagUpdate(c.Service(), form))
 }

--- a/portal/web/api/v1/route.go
+++ b/portal/web/api/v1/route.go
@@ -67,6 +67,7 @@ func Register(g *gin.RouterGroup) {
 	g.GET("/runners", ac(), w(handlers.RunnerSearch))
 	g.PUT("/consul/tags/update", ac(), w(handlers.ConsulTagUpdate))
 	g.GET("/consul/kv/search", ac(), w(handlers.ConsulKVSearch))
+	g.GET("/runners/tags", ac(), w(handlers.RunnerTags)) // 返回所有的runner tags
 
 	ctrl.Register(g.Group("orgs", ac()), &handlers.Organization{})
 	g.PUT("/orgs/:id/status", ac(), w(handlers.Organization{}.ChangeOrgStatus))

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -618,3 +618,20 @@ func UniqStrings(list []string) []string {
 	}
 	return list
 }
+
+func ListContains(originlist, subList []string) bool {
+	for _, sub := range subList {
+		isContain := false
+		for _, origin := range originlist {
+			if sub == origin {
+				isContain = true
+				break
+			}
+		}
+		if !isContain {
+			return false
+		}
+	}
+
+	return true
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -602,23 +602,6 @@ func FileNameWithoutExt(filePath string) string {
 	return strings.TrimSuffix(filepath.Base(filePath), filepath.Ext(filePath))
 }
 
-func UniqStrings(list []string) []string {
-	// 创建一个临时map用来存储数组元素
-	temp := make(map[string]bool)
-	index := 0
-	for _, v := range list {
-		// 遍历数组元素，判断此元素是否已经存在map中
-		_, ok := temp[v]
-		if ok {
-			list = append(list[:index], list[index+1:]...)
-		} else {
-			temp[v] = true
-		}
-		index++
-	}
-	return list
-}
-
 func ListContains(originlist, subList []string) bool {
 	for _, sub := range subList {
 		isContain := false

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -601,3 +601,20 @@ func RecoverdCall(fn func(), recoverFuncs ...func(error)) {
 func FileNameWithoutExt(filePath string) string {
 	return strings.TrimSuffix(filepath.Base(filePath), filepath.Ext(filePath))
 }
+
+func UniqStrings(list []string) []string {
+	// 创建一个临时map用来存储数组元素
+	temp := make(map[string]bool)
+	index := 0
+	for _, v := range list {
+		// 遍历数组元素，判断此元素是否已经存在map中
+		_, ok := temp[v]
+		if ok {
+			list = append(list[:index], list[index+1:]...)
+		} else {
+			temp[v] = true
+		}
+		index++
+	}
+	return list
+}


### PR DESCRIPTION
按照tags匹配runner，并且兼容之前按照id匹配runner的方式。
修改涉及的API主要内容包括：
1.  变更（PUT /api/v1/consul/tags/update）增加权限控制，只有平台管理员可以编辑runner的tag
2.  新增（GET /api/v1/runners/tags），返回所有的tags
3.  变更（POST /api/v1/envs），runner相关参数增加runner_tags数组，为了兼容之前的环境runner_id参数保留。
4.  变更（GET /api/v1/envs/{envId}），返回值中增加runner_tags信息。
5.  变更（GET /api/v1/envs），返回值中增加runner_tags信息。
6.  变更（POST /api/v1/envs/:id/deploy）deploy时，根据选择的runner_tags，确定一个runner_id