### PR TITLE
部署历史增加筛选条件

### DIFF
--- a/portal/apps/task.go
+++ b/portal/apps/task.go
@@ -42,10 +42,10 @@ func SearchTask(c *ctx.ServiceContext, form *forms.SearchTaskForm) (interface{},
 		query = query.Where("iac_task.source = ?", form.Source)
 	}
 	//根据执行人名称或邮箱查询
-	if form.Q != "" {
-		qs := "%" + form.Q + "%"
+	if form.User != "" {
+		users := "%" + form.User + "%"
 		query = query.Joins("left join iac_user on iac_task.creator_id = iac_user.id")
-		query = query.Where("iac_user.name like ?  or iac_user.email LIKE ?", qs, qs)
+		query = query.Where("iac_user.name like ?  or iac_user.email LIKE ?", users, users)
 	}
 	// 默认按创建时间逆序排序
 	if form.SortField() == "" {

--- a/portal/models/forms/task.go
+++ b/portal/models/forms/task.go
@@ -35,7 +35,10 @@ type TaskLogForm struct {
 type SearchTaskForm struct {
 	NoPageSizeForm
 
-	EnvId models.Id `json:"envId" form:"envId" binding:"required"` // 环境ID
+	EnvId    models.Id `json:"envId" form:"envId" binding:"required"` // 环境ID
+	TaskType string    `form:"taskType" json:"taskType" binding:""`   // 任务类型
+	Source   string    `form:"source" json:"source"`                  // 触发类型
+	Q        string    `form:"q" json:"q"`                            // 可根据执行人姓名或邮箱模糊查询
 }
 
 type LastTaskForm struct {
@@ -76,7 +79,10 @@ type ApproveTaskForm struct {
 type SearchEnvTasksForm struct {
 	NoPageSizeForm
 
-	Id models.Id `uri:"id" json:"id" swaggerignore:"true"` // 环境ID，swagger 参数通过 param path 指定，这里忽略
+	Id       models.Id `uri:"id" json:"id" swaggerignore:"true"`    // 环境ID，swagger 参数通过 param path 指定，这里忽略
+	TaskType string    `form:"taskType" json:"taskType" binding:""` // 任务类型
+	Source   string    `form:"source" json:"source"`                // 触发类型
+	Q        string    `form:"q" json:"q"`                          // 可根据执行人姓名或邮箱模糊查询
 }
 
 type SearchTaskResourceForm struct {

--- a/portal/models/forms/task.go
+++ b/portal/models/forms/task.go
@@ -38,7 +38,7 @@ type SearchTaskForm struct {
 	EnvId    models.Id `json:"envId" form:"envId" binding:"required"` // 环境ID
 	TaskType string    `form:"taskType" json:"taskType" binding:""`   // 任务类型
 	Source   string    `form:"source" json:"source"`                  // 触发类型
-	Q        string    `form:"q" json:"q"`                            // 可根据执行人姓名或邮箱模糊查询
+	User     string    `form:"user" json:"user"`                      // 可根据执行人姓名或邮箱模糊查询
 }
 
 type LastTaskForm struct {
@@ -82,7 +82,7 @@ type SearchEnvTasksForm struct {
 	Id       models.Id `uri:"id" json:"id" swaggerignore:"true"`    // 环境ID，swagger 参数通过 param path 指定，这里忽略
 	TaskType string    `form:"taskType" json:"taskType" binding:""` // 任务类型
 	Source   string    `form:"source" json:"source"`                // 触发类型
-	Q        string    `form:"q" json:"q"`                          // 可根据执行人姓名或邮箱模糊查询
+	User     string    `form:"user" json:"user"`                    // 可根据执行人姓名或邮箱模糊查询
 }
 
 type SearchTaskResourceForm struct {

--- a/portal/web/api/v1/handlers/env.go
+++ b/portal/web/api/v1/handlers/env.go
@@ -233,7 +233,7 @@ func (Env) SearchTasks(c *ctx.GinRequest) {
 		EnvId:          form.Id,
 		TaskType:       form.TaskType,
 		Source:         form.Source,
-		Q:              form.Q,
+		User:           form.User,
 	}
 	c.JSONResult(apps.SearchTask(c.Service(), taskForm))
 }

--- a/portal/web/api/v1/handlers/env.go
+++ b/portal/web/api/v1/handlers/env.go
@@ -231,6 +231,9 @@ func (Env) SearchTasks(c *ctx.GinRequest) {
 	taskForm := &forms.SearchTaskForm{
 		NoPageSizeForm: form.NoPageSizeForm,
 		EnvId:          form.Id,
+		TaskType:       form.TaskType,
+		Source:         form.Source,
+		Q:              form.Q,
 	}
 	c.JSONResult(apps.SearchTask(c.Service(), taskForm))
 }


### PR DESCRIPTION
●查询环境部署历史的接口增加筛选字段: 任务类型、触发类型、执行人姓名、执行人邮箱
● 其中姓名和邮箱为模糊搜索，其他字段为全词匹配