### PR TITLE
Feat task step timeout configurable

### DIFF
--- a/cmds/portal/main.go
+++ b/cmds/portal/main.go
@@ -222,7 +222,7 @@ func initSystemConfig(tx *db.Session) (err error) {
 			Description: "日志保存周期",
 		}, {
 			Name:        models.SysCfgNameTaskStepTimeout,
-			Value:       "1800",
+			Value:       "3600",
 			Description: "步骤超时时间",
 		},
 	}

--- a/cmds/portal/main.go
+++ b/cmds/portal/main.go
@@ -217,10 +217,13 @@ func initSystemConfig(tx *db.Session) (err error) {
 			Value:       "100",
 			Description: "每个CT-Runner同时启动的最大容器数",
 		}, {
-
 			Name:        models.SysCfgNamePeriodOfLogSave,
 			Value:       "Permanent",
 			Description: "日志保存周期",
+		}, {
+			Name:        models.SysCfgNameTaskStepTimeout,
+			Value:       "1800",
+			Description: "步骤超时时间",
 		},
 	}
 

--- a/common/consts.go
+++ b/common/consts.go
@@ -82,7 +82,7 @@ const (
 	TaskTypeTplParseName = "tplParse"
 
 	// 默认步骤超时时间(秒)
-	DefaultTaskStepTimeout = 1800
+	DefaultTaskStepTimeout = 3600
 
 	VcsGitlab = "gitlab"
 	VcsGitea  = "gitea"

--- a/portal/apps/env.go
+++ b/portal/apps/env.go
@@ -139,8 +139,8 @@ func setDefaultValueFromTpl(form *forms.CreateEnvForm, tpl *models.Template, des
 		form.Revision = tpl.RepoRevision
 	}
 
-	if form.Timeout == 0 {
-		form.Timeout = common.DefaultTaskStepTimeout
+	if form.StepTimeout == 0 {
+		form.StepTimeout = common.DefaultTaskStepTimeout
 	}
 
 	if form.DestroyAt != "" {
@@ -318,7 +318,7 @@ func CreateEnv(c *ctx.ServiceContext, form *forms.CreateEnvForm) (*models.EnvDet
 		return nil, err
 	}
 
-	taskStepTimeout, err := getTaskStepTimeout(form.Timeout)
+	taskStepTimeout, err := getTaskStepTimeout(form.StepTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -329,13 +329,13 @@ func CreateEnv(c *ctx.ServiceContext, form *forms.CreateEnvForm) (*models.EnvDet
 		CreatorId: c.UserId,
 		TplId:     form.TplId,
 
-		Name:       form.Name,
-		Tags:       strings.TrimSpace(form.Tags),
-		RunnerId:   runnerId,
-		RunnerTags: strings.Join(form.RunnerTags, ","),
-		Status:     models.EnvStatusInactive,
-		OneTime:    form.OneTime,
-		Timeout:    taskStepTimeout,
+		Name:        form.Name,
+		Tags:        strings.TrimSpace(form.Tags),
+		RunnerId:    runnerId,
+		RunnerTags:  strings.Join(form.RunnerTags, ","),
+		Status:      models.EnvStatusInactive,
+		OneTime:     form.OneTime,
+		StepTimeout: taskStepTimeout,
 
 		// 模板参数
 		TfVarsFile:   form.TfVarsFile,
@@ -393,7 +393,7 @@ func CreateEnv(c *ctx.ServiceContext, form *forms.CreateEnvForm) (*models.EnvDet
 		StopOnViolation: env.StopOnViolation,
 		BaseTask: models.BaseTask{
 			Type:        form.TaskType,
-			StepTimeout: form.Timeout,
+			StepTimeout: form.StepTimeout,
 			RunnerId:    runnerId,
 		},
 		ExtraData: models.JSON(form.ExtraData),
@@ -617,8 +617,8 @@ func setUpdateEnvByForm(attrs models.Attrs, form *forms.UpdateEnvForm) {
 	if form.HasKey("policyEnable") {
 		attrs["policyEnable"] = form.PolicyEnable
 	}
-	if form.HasKey("timeout") {
-		attrs["timeout"] = form.Timeout
+	if form.HasKey("stepTimeout") {
+		attrs["stepTimeout"] = form.StepTimeout
 	}
 }
 
@@ -916,8 +916,8 @@ func setEnvByForm(env *models.Env, form *forms.DeployEnvForm) {
 		env.KeyId = form.KeyId
 	}
 
-	if form.HasKey("timeout") {
-		env.Timeout = form.Timeout
+	if form.HasKey("stepTimeout") {
+		env.StepTimeout = form.StepTimeout
 	}
 
 	if form.HasKey("tfVarsFile") {
@@ -1147,7 +1147,7 @@ func envDeploy(c *ctx.ServiceContext, tx *db.Session, form *forms.DeployEnvForm)
 		StopOnViolation: env.StopOnViolation,
 		BaseTask: models.BaseTask{
 			Type:        form.TaskType,
-			StepTimeout: form.Timeout,
+			StepTimeout: form.StepTimeout,
 			RunnerId:    rId,
 		},
 	})

--- a/portal/apps/token.go
+++ b/portal/apps/token.go
@@ -202,7 +202,7 @@ func ApiTriggerHandler(c *ctx.ServiceContext, form forms.ApiTriggerHandler) (int
 		AutoApprove: env.AutoApproval,
 		BaseTask: models.BaseTask{
 			Type:        taskType,
-			StepTimeout: env.Timeout,
+			StepTimeout: env.StepTimeout,
 			RunnerId:    env.RunnerId,
 		},
 	}

--- a/portal/apps/webhook.go
+++ b/portal/apps/webhook.go
@@ -152,7 +152,7 @@ func CreateWebhookTask(tx *db.Session, param CreateWebhookTaskParam) error {
 		BaseTask: models.BaseTask{
 			Type:        param.TaskType,
 			RunnerId:    env.RunnerId,
-			StepTimeout: env.Timeout,
+			StepTimeout: env.StepTimeout,
 		},
 		Source: param.Source,
 	}

--- a/portal/models/env.go
+++ b/portal/models/env.go
@@ -36,11 +36,11 @@ type Env struct {
 	Description string `json:"description" gorm:"type:text"`                                                               // 环境描述
 	Status      string `json:"status" gorm:"type:enum('active','failed','inactive')" enums:"'active','failed','inactive'"` // 环境状态, active活跃, inactive非活跃,failed错误,running部署中,approving审批中
 	// 任务状态，只同步部署任务的状态(apply,destroy)，plan 任务不会对环境产生影响，所以不同步
-	TaskStatus string `json:"taskStatus" gorm:"type:enum('','approving','running');default:''"`
-	Archived   bool   `json:"archived" gorm:"default:false"`            // 是否已归档
-	Timeout    int    `json:"timeout" gorm:"default:1800;comment:部署超时"` // 步骤超时时间（单位：秒）
-	OneTime    bool   `json:"oneTime" gorm:"default:false"`             // 一次性环境标识
-	Deploying  bool   `json:"deploying" gorm:"not null;default:false"`  // 是否正在执行部署
+	TaskStatus  string `json:"taskStatus" gorm:"type:enum('','approving','running');default:''"`
+	Archived    bool   `json:"archived" gorm:"default:false"`            // 是否已归档
+	StepTimeout int    `json:"timeout" gorm:"default:3600;comment:部署超时"` // 步骤超时时间（单位：秒）
+	OneTime     bool   `json:"oneTime" gorm:"default:false"`             // 一次性环境标识
+	Deploying   bool   `json:"deploying" gorm:"not null;default:false"`  // 是否正在执行部署
 
 	Tags string `json:"tags" gorm:"type:text"`
 

--- a/portal/models/forms/env.go
+++ b/portal/models/forms/env.go
@@ -29,7 +29,7 @@ type CreateEnvForm struct {
 	RunnerId        string   `form:"runnerId" json:"runnerId" binding:""`                             // 环境默认部署通道
 	RunnerTags      []string `form:"runnerTags" json:"runnerTags" binding:""`                         // 环境默认部署通道tags
 	Revision        string   `form:"revision" json:"revision" binding:""`                             // 分支/标签
-	Timeout         int      `form:"timeout" json:"timeout" binding:""`                               // 部署超时时间（单位：秒）
+	StepTimeout     int      `form:"stepTimeout" json:"stepTimeout" binding:""`                       // 部署超时时间（单位：秒）
 
 	Variables []Variable `form:"variables" json:"variables" binding:""` // 自定义变量列表，该变量列表会覆盖现有的变量
 
@@ -85,8 +85,8 @@ type UpdateEnvForm struct {
 	RunnerId    string    `form:"runnerId" json:"runnerId" binding:""`              // 环境默认部署通道
 	Archived    bool      `form:"archived" json:"archived" enums:"true,false"`      // 归档状态，默认返回未归档环境
 
-	Timeout int    `form:"timeout" json:"timeout" binding:""` // 部署超时时间（单位：秒）
-	Tags    string `form:"tags" json:"tags" binding:""`       // 环境的 tags，多个 tag 以 "," 分隔
+	StepTimeout int    `form:"stepTimeout" json:"stepTimeout" binding:""` // 部署超时时间（单位：秒）
+	Tags        string `form:"tags" json:"tags" binding:""`               // 环境的 tags，多个 tag 以 "," 分隔
 
 	AutoApproval    bool `form:"autoApproval" json:"autoApproval"  binding:"" enums:"true,false"` // 是否自动审批
 	StopOnViolation bool `form:"stopOnViolation" json:"stopOnViolation" enums:"true,false"`       // 合规不通过是否中止任务
@@ -114,12 +114,12 @@ type DeployEnvForm struct {
 	AutoApproval    bool     `form:"autoApproval" json:"autoApproval"  binding:"" enums:"true,false"` // 是否自动审批
 	StopOnViolation bool     `form:"stopOnViolation" json:"stopOnViolation" enums:"true,false"`       // 合规不通过是否中止任务
 
-	TaskType   string   `form:"taskType" json:"taskType" binding:"required" enums:"plan,apply,destroy"` // 环境创建后触发的任务步骤，plan计划,apply部署,destroy销毁资源
-	Targets    string   `form:"targets" json:"targets" binding:""`                                      // Terraform target 参数列表
-	RunnerId   string   `form:"runnerId" json:"runnerId" binding:""`                                    // 环境默认部署通道
-	RunnerTags []string `form:"runnerTags" json:"runnerTags" binding:""`                                // 环境默认部署通道Tags
-	Revision   string   `form:"revision" json:"revision" binding:""`                                    // 分支/标签
-	Timeout    int      `form:"timeout" json:"timeout" binding:""`                                      // 部署超时时间（单位：秒）
+	TaskType    string   `form:"taskType" json:"taskType" binding:"required" enums:"plan,apply,destroy"` // 环境创建后触发的任务步骤，plan计划,apply部署,destroy销毁资源
+	Targets     string   `form:"targets" json:"targets" binding:""`                                      // Terraform target 参数列表
+	RunnerId    string   `form:"runnerId" json:"runnerId" binding:""`                                    // 环境默认部署通道
+	RunnerTags  []string `form:"runnerTags" json:"runnerTags" binding:""`                                // 环境默认部署通道Tags
+	Revision    string   `form:"revision" json:"revision" binding:""`                                    // 分支/标签
+	StepTimeout int      `form:"stepTimeout" json:"stepTimeout" binding:""`                              // 部署超时时间（单位：秒）
 
 	RetryNumber int  `form:"retryNumber" json:"retryNumber" binding:""` // 重试总次数
 	RetryDelay  int  `form:"retryDelay" json:"retryDelay" binding:""`   // 重试时间间隔

--- a/portal/models/forms/env.go
+++ b/portal/models/forms/env.go
@@ -85,7 +85,8 @@ type UpdateEnvForm struct {
 	RunnerId    string    `form:"runnerId" json:"runnerId" binding:""`              // 环境默认部署通道
 	Archived    bool      `form:"archived" json:"archived" enums:"true,false"`      // 归档状态，默认返回未归档环境
 
-	Tags string `form:"tags" json:"tags" binding:""` // 环境的 tags，多个 tag 以 "," 分隔
+	Timeout int    `form:"timeout" json:"timeout" binding:""` // 部署超时时间（单位：秒）
+	Tags    string `form:"tags" json:"tags" binding:""`       // 环境的 tags，多个 tag 以 "," 分隔
 
 	AutoApproval    bool `form:"autoApproval" json:"autoApproval"  binding:"" enums:"true,false"` // 是否自动审批
 	StopOnViolation bool `form:"stopOnViolation" json:"stopOnViolation" enums:"true,false"`       // 合规不通过是否中止任务

--- a/portal/models/runner_task.go
+++ b/portal/models/runner_task.go
@@ -21,7 +21,7 @@ type BaseTask struct {
 	ContainerId string `json:"-" gorm:"size:64"`
 
 	// 任务每一步的执行超时(整个任务无超时控制)
-	StepTimeout int `json:"stepTimeout" gorm:"default:1800;comment:执行超时"`
+	StepTimeout int `json:"stepTimeout" gorm:"default:3600;comment:执行超时"`
 
 	RunnerId string `json:"runnerId" gorm:"not null"` // 部署通道
 

--- a/portal/models/sys_cfg.go
+++ b/portal/models/sys_cfg.go
@@ -10,6 +10,7 @@ const (
 	SysCfgNameMaxJobsPerRunner = "MAX_JOBS_PER_RUNNER"
 	SysCfgNamePeriodOfLogSave  = "PERIOD_OF_LOG_SAVE"
 	SysCfgNamRegistryAddr      = "REGISTRY_ADDR"
+	SysCfgNameTaskStepTimeout  = "TASK_STEP_TIMEOUT"
 )
 
 type SystemCfg struct {


### PR DESCRIPTION
### 步骤超时时间可配置
1. iac_system_cfg 表增加 name 为TASK_STEP_TIMEOUT 的记录, 默认值为 3600 (60分钟)
2. 平台设置页面增加步骤超时时间设置, 用于修改 TASK_STEP_TIMEOUT
3. 环境创建, 更新, 重新部署时可以配置步骤超时时间，默认值为 TASK_STEP_TIMEOUT
