### PR TITLE
Fix: 支持带 Bearer 的token

### DIFF
--- a/portal/web/middleware/auth.go
+++ b/portal/web/middleware/auth.go
@@ -80,6 +80,11 @@ func Auth(c *ctx.GinRequest) {
 		return
 	}
 
+	// Remove Bearer from token string
+	if len(tokenStr) > 6 && tokenStr[0:6] == "Bearer" {
+		tokenStr = tokenStr[7:]
+	}
+
 	apiTokenOrgId, err := checkToken(c, tokenStr)
 	if err != nil {
 		c.JSONError(e.New(e.InvalidToken), http.StatusUnauthorized)


### PR DESCRIPTION
现在的 token header 为 Authorization: {{jwt_token}}，jwt 推荐格式为 Authorization: Bearer {{jwt_token}}
这个 pr 包含了这个兼容性支持。