### PR TITLE
fix: 修复 stepTimeout 错误问题

### DIFF
--- a/portal/apps/env.go
+++ b/portal/apps/env.go
@@ -176,16 +176,17 @@ func getRunnerId(runnerTags []string, runnerId string) (string, e.Error) {
 	return services.GetDefaultRunner()
 }
 
-// getTaskStepTimeout return timeout in second
-func getTaskStepTimeout(timeout int) (int, e.Error) {
-	if timeout <= 0 {
+// getTaskStepTimeoutInSecond return timeout in second
+func getTaskStepTimeoutInSecond(timeoutInMinute int) (int, e.Error) {
+	timeoutInSecond := timeoutInMinute * 60
+	if timeoutInSecond <= 0 {
 		sysTimeout, err := services.GetSystemTaskStepTimeout(db.Get())
 		if err != nil {
 			return -1, err
 		}
-		timeout = sysTimeout
+		timeoutInSecond = sysTimeout
 	}
-	return timeout / 60, nil
+	return timeoutInSecond, nil
 }
 
 func createEnvToDB(tx *db.Session, c *ctx.ServiceContext, form *forms.CreateEnvForm, envModel models.Env) (*models.Env, e.Error) {
@@ -321,7 +322,7 @@ func CreateEnv(c *ctx.ServiceContext, form *forms.CreateEnvForm) (*models.EnvDet
 		return nil, err
 	}
 
-	taskStepTimeout, err := getTaskStepTimeout(form.StepTimeout)
+	taskStepTimeout, err := getTaskStepTimeoutInSecond(form.StepTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/portal/apps/env.go
+++ b/portal/apps/env.go
@@ -397,7 +397,7 @@ func CreateEnv(c *ctx.ServiceContext, form *forms.CreateEnvForm) (*models.EnvDet
 		StopOnViolation: env.StopOnViolation,
 		BaseTask: models.BaseTask{
 			Type:        form.TaskType,
-			StepTimeout: form.StepTimeout,
+			StepTimeout: taskStepTimeout,
 			RunnerId:    runnerId,
 		},
 		ExtraData: models.JSON(form.ExtraData),


### PR DESCRIPTION
### 修复错误的时间转换
- 创建环境的时候步骤超时时间使用了错误的表单参数
- getTaskStepTimout 时间转换出错