### PR TITLE
fix:优化环境重新部署检测接口检测云模板规则

### DIFF
--- a/docs/lang.csv
+++ b/docs/lang.csv
@@ -137,3 +137,4 @@
 31710,LdapConnectFailed,ldap 服务器连接 失败,ldap servers connect failed
 31720,LdapNotAllowUpdate,ldap 账号不支持修改,Ldap account cannot be modified
 314410,InvalidVarGroup,无效资源账号,invalid resource account
+30823,TemplateNotBind,云模板未绑定当前项目,template is not bound to the project

--- a/portal/apps/env.go
+++ b/portal/apps/env.go
@@ -902,18 +902,6 @@ func EnvDeployCheck(c *ctx.ServiceContext, envId models.Id) (interface{}, e.Erro
 	if checkErr != nil {
 		return nil, checkErr
 	}
-	//检测云模板是否合法
-	if err = TemplateDeployCheck(c, &forms.TemplateChecksForm{
-		Name:         tpl.Name,
-		RepoId:       tpl.RepoId,
-		VcsId:        tpl.VcsId,
-		Workdir:      env.Workdir,
-		TfVarsFile:   env.TfVarsFile,
-		Playbook:     env.Playbook,
-		RepoRevision: env.Revision,
-	}); err != nil {
-		return nil, err
-	}
 	//vcs 检测(是否禁用，token是否有效)
 	vcs, err := services.GetVcsById(c.DB(), tpl.VcsId)
 	if err != nil {

--- a/portal/apps/env.go
+++ b/portal/apps/env.go
@@ -899,12 +899,12 @@ func EnvDeployCheck(c *ctx.ServiceContext, envId models.Id) (interface{}, e.Erro
 	}
 	if err = TemplateDeployCheck(c, &forms.TemplateChecksForm{
 		Name:         tpl.Name,
-		Workdir:      tpl.Workdir,
-		TfVarsFile:   tpl.TfVarsFile,
-		Playbook:     tpl.Playbook,
 		RepoId:       tpl.RepoId,
-		RepoRevision: tpl.RepoRevision,
 		VcsId:        tpl.VcsId,
+		Workdir:      env.Workdir,
+		TfVarsFile:   env.TfVarsFile,
+		Playbook:     env.Playbook,
+		RepoRevision: env.Revision,
 	}); err != nil {
 		return nil, err
 	}

--- a/portal/apps/template.go
+++ b/portal/apps/template.go
@@ -531,27 +531,6 @@ func TemplateChecks(c *ctx.ServiceContext, form *forms.TemplateChecksForm) (inte
 	}, nil
 }
 
-//TemplateDeployCheck 只检测选择的目录下template是否合法
-func TemplateDeployCheck(c *ctx.ServiceContext, form *forms.TemplateChecksForm) e.Error {
-	// 检查工作目录下.tf 文件是否存在
-	if form.Workdir != "" {
-		searchForm := &forms.RepoFileSearchForm{
-			RepoId:       form.RepoId,
-			RepoRevision: form.RepoRevision,
-			VcsId:        form.VcsId,
-			Workdir:      form.Workdir,
-		}
-		results, err := VcsRepoFileSearch(c, searchForm, "", consts.TfFileMatch)
-		if err != nil {
-			return err
-		}
-		if len(results) == 0 {
-			return e.New(e.TemplateWorkdirError, fmt.Errorf("no '%s' files", consts.TfFileMatch))
-		}
-	}
-	return nil
-}
-
 func CheckTemplateOrEnvConfig(c *ctx.ServiceContext, tfVarsFile, playbook, repoId, reporevision, workdir string, vcsId models.Id) (e.Error, TplCheckResult) {
 	checkResult := TplCheckResult{}
 	if tfVarsFile != "" {

--- a/portal/apps/template.go
+++ b/portal/apps/template.go
@@ -531,9 +531,10 @@ func TemplateChecks(c *ctx.ServiceContext, form *forms.TemplateChecksForm) (inte
 	}, nil
 }
 
+//TemplateDeployCheck 只检测选择的目录下template是否合法
 func TemplateDeployCheck(c *ctx.ServiceContext, form *forms.TemplateChecksForm) e.Error {
+	// 检查工作目录下.tf 文件是否存在
 	if form.Workdir != "" {
-		// 检查工作目录下.tf 文件是否存在
 		searchForm := &forms.RepoFileSearchForm{
 			RepoId:       form.RepoId,
 			RepoRevision: form.RepoRevision,
@@ -547,13 +548,6 @@ func TemplateDeployCheck(c *ctx.ServiceContext, form *forms.TemplateChecksForm) 
 		if len(results) == 0 {
 			return e.New(e.TemplateWorkdirError, fmt.Errorf("no '%s' files", consts.TfFileMatch))
 		}
-	}
-	err, checkResult := CheckTemplateOrEnvConfig(c, form.TfVarsFile, form.Playbook, form.RepoId, form.RepoRevision, form.Workdir, form.VcsId)
-	if err != nil {
-		return err
-	}
-	if checkResult.Playbook.Error != "" || checkResult.TfVars.Error != "" {
-		return e.New(e.BadParam)
 	}
 	return nil
 }

--- a/portal/consts/e/errors.go
+++ b/portal/consts/e/errors.go
@@ -150,6 +150,7 @@ const (
 	EnvLockFailedTaskActive = 30817
 	EnvTagNumLimited        = 30821
 	EnvTagLengthLimited     = 30822
+	TemplateNotBind         = 30823
 
 	//// task 309
 	TaskAlreadyExists     = 30910

--- a/portal/services/template.go
+++ b/portal/services/template.go
@@ -8,6 +8,7 @@ import (
 	"cloudiac/portal/libs/db"
 	"cloudiac/portal/models"
 	"fmt"
+	"github.com/pkg/errors"
 	"strings"
 
 	"gorm.io/gorm"
@@ -190,4 +191,16 @@ func GetAvailableTemplateIdsByUserId(sess *db.Session, userId, orgId models.Id) 
 		return nil, e.AutoNew(err, e.DBError)
 	}
 	return tplIds, nil
+}
+
+func GetBindTemplate(sess *db.Session, projectId, tplId models.Id) (*models.ProjectTemplate, e.Error) {
+	pt := models.ProjectTemplate{}
+	if err := sess.Model(&models.ProjectTemplate{}).Where("project_id = ? and template_id = ?",
+		projectId, tplId).First(&pt); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, e.New(e.TemplateNotBind, err)
+		}
+		return nil, e.AutoNew(err, e.DBError)
+	}
+	return &pt, nil
 }


### PR DESCRIPTION
当检测云模板的时候，选择历史部署选择的工作目录，tfvars文件、playbook文件已经revision当成一个云模板进行检测