### PR TITLE
fix: 修复开启 terraform debug 执行 terraform.py 出错

### DIFF
--- a/assets/terraform.py
+++ b/assets/terraform.py
@@ -374,6 +374,7 @@ def _execute_shell():
         sys.stderr.write(str(err_ws) + '\n')
         sys.exit(1)
     else:
+        os.putenv("TF_LOG", "")
         tf_command = [TERRAFORM_PATH, 'state', 'pull']
         proc_tf_cmd = Popen(tf_command,
                             cwd=TERRAFORM_DIR,


### PR DESCRIPTION
当 TF_LOG 设置为 debug 时, 执行 terraform state pull 会带上 debug 日志输出, 导致 terrafom.py 解析 json 出错;