### PR TITLE
fix bug 脚本参数缺失和env表字段

### DIFF
--- a/portal/models/env.go
+++ b/portal/models/env.go
@@ -33,9 +33,9 @@ type Env struct {
 	TplId     Id `json:"tplId" gorm:"size:32;not null"`     // 模板ID
 	CreatorId Id `json:"creatorId" gorm:"size:32;not null"` // 创建人ID
 
-	Name        string `json:"name" gorm:"not null"`                                                                       // 环境名称
-	Description string `json:"description" gorm:"type:text"`                                                               // 环境描述
-	Status      string `json:"status" gorm:"type:enum('active','failed','inactive')" enums:"'active','failed','inactive'"` // 环境状态, active活跃, inactive非活跃,failed错误,running部署中,approving审批中
+	Name        string `json:"name" gorm:"not null"`                                                                                                 // 环境名称
+	Description string `json:"description" gorm:"type:text"`                                                                                         // 环境描述
+	Status      string `json:"status" gorm:"type:enum('active','failed','inactive', 'destroyed')" enums:"'active','failed','inactive', 'destroyed'"` // 环境状态, active活跃, inactive非活跃,failed错误,running部署中,approving审批中
 	// 任务状态，只同步部署任务的状态(apply,destroy)，plan 任务不会对环境产生影响，所以不同步
 	TaskStatus  string `json:"taskStatus" gorm:"type:enum('','approving','running');default:''"`
 	Archived    bool   `json:"archived" gorm:"default:false"`                // 是否已归档

--- a/runner/task.go
+++ b/runner/task.go
@@ -539,7 +539,9 @@ func (t *Task) stepDestroy() (command string, err error) {
 	// destroy 任务通过会先执行 plan(传入 --destroy 参数)，然后再 apply plan 文件实现。
 	// 这样可以保证 destroy 时执行的是用户审批时看到的 plan 内容
 	return t.executeTpl(applyCommandTpl, map[string]interface{}{
-		"Req": t.req,
+		"Req":                 t.req,
+		"TFStateJsonFilePath": t.up2Workspace(TFStateJsonFile),
+		"TFProviderSchema":    t.up2Workspace(TFProviderSchema),
 	})
 }
 


### PR DESCRIPTION
1. destroy时脚本字段缺失
2. env表的status字段增加 destroyed选项

```
ALTER TABLE cloudiac.iac_env MODIFY COLUMN status enum('active','failed','inactive','destroyed') CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL;
```