### PR TITLE
Fix service restart error

### DIFF
--- a/cmds/common/register.go
+++ b/cmds/common/register.go
@@ -121,11 +121,8 @@ func acquireLock(ctx context.Context, serviceId string, isTryOnce bool) (<-chan 
 	lockHeld := false
 	go func() {
 		<-ctx.Done()
-		fmt.Println("start to unlock1111")
 		close(stopLockCh)
-		fmt.Println("start to unlock2222")
 		if lockHeld {
-			fmt.Println("start to unlock3333")
 			if err := locker.Unlock(); err != nil {
 				logs.Get().Errorf("release lock error: %v", err)
 			}

--- a/common/consts.go
+++ b/common/consts.go
@@ -119,6 +119,7 @@ const (
 	ConsulCakey         = "client.key"
 	ConsulCapem         = "client.pem"
 	ConsulContainerPath = "/cloudiac/cert/"
+	ConsulSessionTTL    = 10
 )
 
 var (

--- a/configs/config.go
+++ b/configs/config.go
@@ -37,6 +37,7 @@ type ConsulConfig struct {
 	ConsulCertPath  string `yaml:"consul_cert_path"`
 	ConsulAclToken  string `yaml:"consul_acl_token"`
 	ConsulTls       bool   `yaml:"consul_tls"`
+	WaitLockRelease int    `yaml:"wait_lock_release"` // 等待 consul 自动释放锁
 }
 
 type RunnerConfig struct {

--- a/configs/config.go
+++ b/configs/config.go
@@ -37,7 +37,6 @@ type ConsulConfig struct {
 	ConsulCertPath  string `yaml:"consul_cert_path"`
 	ConsulAclToken  string `yaml:"consul_acl_token"`
 	ConsulTls       bool   `yaml:"consul_tls"`
-	WaitLockRelease int    `yaml:"wait_lock_release"` // 等待 consul 自动释放锁
 }
 
 type RunnerConfig struct {

--- a/utils/consul/consul_client.go
+++ b/utils/consul/consul_client.go
@@ -7,6 +7,7 @@ import (
 	"cloudiac/portal/services"
 	"cloudiac/utils/consulClient"
 
+	"cloudiac/common"
 	"cloudiac/utils/logs"
 
 	"encoding/json"
@@ -67,9 +68,9 @@ func GetLocker(key string, value []byte, address string, isTryOnce bool) (*consu
 	return client.LockOpts(&consulapi.LockOptions{
 		Key:          key,
 		Value:        value,
-		SessionTTL:   "10s",       // session 超时时间, 超时后锁会被自动锁放
-		LockTryOnce:  isTryOnce,   // false: 重复尝试，直到加锁成功
-		LockWaitTime: time.Second, // 加锁 api 请求的等待时间
-		LockDelay:    time.Second, // consul server 的加锁操作等待时间
+		SessionTTL:   fmt.Sprintf("%ds", common.ConsulSessionTTL), // session 超时时间, 超时后锁会被自动锁放
+		LockTryOnce:  isTryOnce,                                   // false: 重复尝试，直到加锁成功
+		LockWaitTime: time.Second,                                 // 加锁 api 请求的等待时间
+		LockDelay:    time.Second,                                 // consul server 的加锁操作等待时间
 	})
 }


### PR DESCRIPTION
服务重启时，由于上次关闭时，consul上的lock还没有释放（自动释放最快10s左右）。
10s内重启的话，无法启动成功。

目前的方案是启动时尝试2次获取锁，第一次获取失败后，等待 wait_lock_release （单位秒，默认20）。
此配置在 consul 下。