### PR TITLE
fix: 修复 opa 扫描不通过时未展示扫描结果的问题

### DIFF
--- a/portal/services/task_step.go
+++ b/portal/services/task_step.go
@@ -93,20 +93,24 @@ func IsTerraformStep(typ string) bool {
 
 func ChangeTaskStepStatusAndExitCode(dbSess *db.Session, task models.Tasker, taskStep *models.TaskStep,
 	status, message string, exitCode int) e.Error {
-	taskStep.ExitCode = exitCode
-	return ChangeTaskStepStatus(dbSess, task, taskStep, status, message)
+	return changeTaskStepStatusAndExitCode(dbSess, task, taskStep, exitCode, status, message)
 }
 
 // ChangeTaskStepStatus 修改步骤状态并更新 taskStep
 // - 该函数会同步修改任务状态
 // - 该函数仅修改 status, message, start_at, end_at 字段
 func ChangeTaskStepStatus(dbSess *db.Session, task models.Tasker, taskStep *models.TaskStep, status, message string) e.Error {
+	return changeTaskStepStatusAndExitCode(dbSess, task, taskStep, taskStep.ExitCode, status, message)
+}
+
+func changeTaskStepStatusAndExitCode(dbSess *db.Session, task models.Tasker, taskStep *models.TaskStep, exitCode int, status, message string) e.Error {
 	if taskStep.Status == status && message == "" {
 		return nil
 	}
 
 	updateAttrs := models.Attrs{
-		"message": message,
+		"message":   message,
+		"exit_code": exitCode,
 	}
 	taskStep.Message = message
 	if status != "" {


### PR DESCRIPTION
ChangeTaskStepStatusAndExitCode() 修改 step.ExitCode 后未保存到 db，导致扫描步骤的 exitCode 总是为 0 ，
然后 ChangeScanTaskStatusWithStep() 函数中根据任务状态和 step.ExitCode 判断 policyStatus 时总是取了 PolicyStatusFailed