### PR TITLE
refa: 改用 tfvars.json 文件传入 terraform 变量

### DIFF
--- a/runner/consts.go
+++ b/runner/consts.go
@@ -40,6 +40,7 @@ const (
 
 	CloudIacTfFile   = "_cloudiac.tf"
 	CloudIacPlayVars = "_cloudiac_play_vars.yml"
+	CloudIacTfvarsJson = "_cloudiac.tfvars.json"
 
 	TFStateJsonFile  = "tfstate.json"
 	TFPlanJsonFile   = "tfplan.json"


### PR DESCRIPTION
因为使用 TF_VAR_xx 环境变量传入会因为优先级问题导致无法覆盖掉 tfvars 文件中定义的变量，不便于 Stack 的编写。

改为这个方案后，我们可以支持在 stack 中定义不同的 tfvars 文件来对应不同部署场景的默认参数，然后在部署具体环境时对部分参数做修改。

terraform 变量的优先级定义：https://www.terraform.io/language/values/variables#variable-definition-precedence

改为该方案后用户依然可以通过在环境变量中配置带 TF_VAR_xx 前缀的变量。

需要注意，如果 tfvars 文件中有未定义的变量名 terraform 会报一个警告。