### PR TITLE
Fix 步骤超时时间出错

### DIFF
--- a/portal/apps/env.go
+++ b/portal/apps/env.go
@@ -175,8 +175,13 @@ func setDefaultValueFromTpl(form *forms.CreateEnvForm, tpl *models.Template, des
 		}
 	}
 
-	if form.StepTimeout == 0 {
-		form.StepTimeout = common.DefaultTaskStepTimeout
+	if !form.HasKey("stepTimeout") || form.StepTimeout == 0 {
+		stepTimeout, err := services.GetSystemTaskStepTimeout(session)
+		if err != nil {
+			return err
+		}
+		// 以分钟为单位返回
+		form.StepTimeout = stepTimeout / 60
 	}
 
 	if form.DestroyAt != "" {


### PR DESCRIPTION
部署新环境时，步骤超时时间 不传 或者 传0 时，步骤超时时间取系统设置超时时间，并且以分钟为单位返回。