### PR TITLE
Fix 重新部署时无法真正删除 ssh 密钥

### DIFF
--- a/portal/apps/env.go
+++ b/portal/apps/env.go
@@ -1159,9 +1159,11 @@ func setEnvByForm(env *models.Env, form *forms.DeployEnvForm) {
 	if form.HasKey("triggers") {
 		env.Triggers = form.Triggers
 	}
+
 	if form.HasKey("keyId") {
 		env.KeyId = form.KeyId
 	}
+
 	if form.HasKey("stepTimeout") {
 		// 将分钟转换为秒
 		env.StepTimeout = form.StepTimeout * 60
@@ -1485,6 +1487,7 @@ func envDeploy(c *ctx.ServiceContext, tx *db.Session, form *forms.DeployEnvForm)
 	} else {
 		IsDriftTask = false
 	}
+
 	// 创建任务
 	task, err := services.CreateTask(tx, tpl, env, models.Task{
 		Name:            models.Task{}.GetTaskNameByType(form.TaskType),
@@ -1517,6 +1520,7 @@ func envDeploy(c *ctx.ServiceContext, tx *db.Session, form *forms.DeployEnvForm)
 		c.Logger().Errorf("error save env, err %s", err)
 		return nil, e.New(e.DBError, err, http.StatusInternalServerError)
 	}
+
 	env.MergeTaskStatus()
 	envDetail := &models.EnvDetail{
 		Env:    *env,

--- a/portal/apps/env.go
+++ b/portal/apps/env.go
@@ -1537,6 +1537,7 @@ func envDeploy(c *ctx.ServiceContext, tx *db.Session, form *forms.DeployEnvForm)
 	if err := vcsrv.SetWebhook(vcs, tpl.RepoId, token.Key, form.Triggers); err != nil {
 		c.Logger().Errorf("set webhook err :%v", err)
 	}
+	
 	return envDetail, nil
 }
 

--- a/portal/apps/env.go
+++ b/portal/apps/env.go
@@ -1159,11 +1159,9 @@ func setEnvByForm(env *models.Env, form *forms.DeployEnvForm) {
 	if form.HasKey("triggers") {
 		env.Triggers = form.Triggers
 	}
-
 	if form.HasKey("keyId") {
 		env.KeyId = form.KeyId
 	}
-
 	if form.HasKey("stepTimeout") {
 		// 将分钟转换为秒
 		env.StepTimeout = form.StepTimeout * 60
@@ -1432,6 +1430,10 @@ func envDeploy(c *ctx.ServiceContext, tx *db.Session, form *forms.DeployEnvForm)
 		form.Revision = env.Revision
 	}
 
+	if !form.HasKey("keyId") {
+		form.KeyId = env.KeyId
+	}
+
 	// 环境下云模版工作目录检查
 	if err = envWorkdirCheck(c, tpl.RepoId, form.Revision, form.Workdir, tpl.VcsId); err != nil {
 		return nil, err
@@ -1483,7 +1485,6 @@ func envDeploy(c *ctx.ServiceContext, tx *db.Session, form *forms.DeployEnvForm)
 	} else {
 		IsDriftTask = false
 	}
-
 	// 创建任务
 	task, err := services.CreateTask(tx, tpl, env, models.Task{
 		Name:            models.Task{}.GetTaskNameByType(form.TaskType),
@@ -1516,7 +1517,6 @@ func envDeploy(c *ctx.ServiceContext, tx *db.Session, form *forms.DeployEnvForm)
 		c.Logger().Errorf("error save env, err %s", err)
 		return nil, e.New(e.DBError, err, http.StatusInternalServerError)
 	}
-
 	env.MergeTaskStatus()
 	envDetail := &models.EnvDetail{
 		Env:    *env,

--- a/portal/services/task.go
+++ b/portal/services/task.go
@@ -204,7 +204,7 @@ func newCommonTask(tpl *models.Template, env *models.Env, pt models.Task) (*mode
 		CreatorId:       pt.CreatorId,
 		Variables:       pt.Variables,
 		AutoApprove:     pt.AutoApprove,
-		KeyId:           pt.KeyId,
+		KeyId:           models.Id(firstVal(string(pt.KeyId), string(env.KeyId))),
 		ExtraData:       pt.ExtraData,
 		Revision:        firstVal(pt.Revision, env.Revision, tpl.RepoRevision),
 		CommitId:        pt.CommitId,

--- a/portal/services/task.go
+++ b/portal/services/task.go
@@ -204,7 +204,7 @@ func newCommonTask(tpl *models.Template, env *models.Env, pt models.Task) (*mode
 		CreatorId:       pt.CreatorId,
 		Variables:       pt.Variables,
 		AutoApprove:     pt.AutoApprove,
-		KeyId:           models.Id(firstVal(string(pt.KeyId), string(env.KeyId), string(tpl.KeyId))),
+		KeyId:           pt.KeyId,
 		ExtraData:       pt.ExtraData,
 		Revision:        firstVal(pt.Revision, env.Revision, tpl.RepoRevision),
 		CommitId:        pt.CommitId,


### PR DESCRIPTION
新建 Stack 选择了 playbook 文件和 ssh 密钥，部署环境时删除 ssh，环境实际执行还是会使用 ssh。
分两种情况：

部署新环境：
协调前端修改，如果 keyid 为空，修改前不传 keyid 参数，修改后前端 keyid 传空。

重新部署：
1. 不传 keyid 参数时，默认取 env 的 keyid。
2.  当 keyid 传空时，在重新部署时，env keyid 和 form keyid 保持一致，都为空。在设置里删除 ssh 密钥后，stack 中的 ssh 密钥还存在，所以去 tpl 的 keyid 会出错。