### PR TITLE
Fix 新建 stack 获取分支和 tags 只能获取 100

### DIFF
--- a/portal/consts/consts.go
+++ b/portal/consts/consts.go
@@ -14,6 +14,8 @@ const (
 	DigitChars      = "0123456789"
 	SpecialChars    = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
 
+	GitlabPerPageSize = 100 // Gitlab 单页大小最大限制
+
 	DefaultPageSize = 15   // 默认分页大小
 	MaxPageSize     = 5000 // 最大单页数据条数
 

--- a/portal/services/vcsrv/gitlab.go
+++ b/portal/services/vcsrv/gitlab.go
@@ -3,6 +3,7 @@
 package vcsrv
 
 import (
+	"cloudiac/portal/consts"
 	"cloudiac/portal/consts/e"
 	"cloudiac/portal/models"
 	"cloudiac/utils"
@@ -105,35 +106,57 @@ type gitlabRepoIface struct {
 
 func (git *gitlabRepoIface) ListBranches() ([]string, error) {
 	branchList := make([]string, 0)
-	opt := &gitlab.ListBranchesOptions{ListOptions: gitlab.ListOptions{
-		Page:    1,
-		PerPage: 5000,
-	}}
+	currentPage := 1
 
-	branches, _, er := git.gitConn.Branches.ListBranches(git.Project.ID, opt)
-	if er != nil {
-		return nil, e.New(e.VcsError, er)
+	for {
+		branches, response, er := git.gitConn.Branches.ListBranches(git.Project.ID,
+			&gitlab.ListBranchesOptions{
+				ListOptions: gitlab.ListOptions{
+					Page:    currentPage,
+					PerPage: consts.GitlabPerPageSize,
+				},
+			})
+		if er != nil {
+			return nil, e.New(e.VcsError, er)
+		}
+
+		for _, branch := range branches {
+			branchList = append(branchList, branch.Name)
+		}
+
+		if currentPage == response.TotalPages {
+			break
+		}
+		currentPage++
 	}
-	for _, branch := range branches {
-		branchList = append(branchList, branch.Name)
-	}
+
 	return branchList, nil
 }
 
 func (git *gitlabRepoIface) ListTags() ([]string, error) {
 	tagList := make([]string, 0)
-	opt := &gitlab.ListTagsOptions{ListOptions: gitlab.ListOptions{
-		Page:    1,
-		PerPage: 5000,
-	}}
+	currentPage := 1
 
-	tags, _, er := git.gitConn.Tags.ListTags(git.Project.ID, opt)
-	if er != nil {
-		return nil, e.New(e.VcsError, er)
+	for {
+		tags, response, er := git.gitConn.Tags.ListTags(git.Project.ID,
+			&gitlab.ListTagsOptions{ListOptions: gitlab.ListOptions{
+				Page:    currentPage,
+				PerPage: consts.GitlabPerPageSize,
+			}})
+		if er != nil {
+			return nil, e.New(e.VcsError, er)
+		}
+
+		for _, tag := range tags {
+			tagList = append(tagList, tag.Name)
+		}
+
+		if currentPage == response.TotalPages {
+			break
+		}
+		currentPage++
 	}
-	for _, tag := range tags {
-		tagList = append(tagList, tag.Name)
-	}
+
 	return tagList, nil
 }
 


### PR DESCRIPTION
由于 gitlab 的限制原因，新建 stack 时获取分支和 tags 只能获取到 100个。
所以当有 1000 个分支和 1000 个 tags 时，会分别请求 gitlab 接口 10 次，进而导致获取时间增加。