### PR TITLE
Fix 事件通知时分支显示 stack 分支名称

### DIFF
--- a/portal/services/notificationrc/notificationservice.go
+++ b/portal/services/notificationrc/notificationservice.go
@@ -89,7 +89,7 @@ func (ns *NotificationService) SyncSendMessage() {
 		OrgName:      ns.Org.Name,
 		ProjectName:  ns.Project.Name,
 		TemplateName: ns.Tpl.Name,
-		Revision:     ns.Tpl.RepoRevision,
+		Revision:     ns.Env.Revision,
 		EnvName:      ns.Env.Name,
 		//http://{{addr}}/org/{{orgId}}/project/{{ProjectId}}/m-project-env/detail/{{envId}}/task/{{TaskId}}
 		Addr:         fmt.Sprintf("%s/org/%s/project/%s/m-project-env/detail/%s/task/%s", configs.Get().Portal.Address, ns.Org.Id, ns.ProjectId, ns.Env.Id, ns.Task.Id),


### PR DESCRIPTION
在部署环境时，分支可能选择的不是 stack 模版分支，但是事件通知时分支显示 stack 模版分支名称，正常应该显示目前环境部署使用的分支名称。