### PR TITLE
fix:新增mode字段识别datasource、resoucre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## v1.3.5 20230224
+
+### Fixed
+- 修复资源列表无法区分datasource和resource的问题
+
+#### 升级步骤
+**升级前注意备份数据**
+
+**数据升级**
+执行 `./iac-tool updateDB resource -m` 进行数据升级。
+如果是容器化部署执行: `docker-compose exec iac-portal ./iac-tool updateDB resource -m`
+
+
 ## v1.3.4 20221224
 ### Fixed
 - 修复删除历史漂移检测任务耗时过长的问题
@@ -511,14 +524,3 @@ SECRET_KEY=xxxx	# 变量值请根据环境进行设置
 ------
 ## v0.5.0 20210728
 全新 0.5.0 版本发布
-
-**Fixes**
-
-- 修复资源列表无法区分datasource和resource的问题
-
-#### 升级步骤
-**升级前注意备份数据**
-
-**数据升级**
-执行 `./iac-tool updateDB resource -m` 进行数据升级。
-如果是容器化部署执行: `docker-compose exec iac-portal ./iac-tool updateDB resource -m`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,3 @@
-## v1.3.5 20230224
-
-### Fixed
-- 修复资源列表无法区分datasource和resource的问题
-
-#### 升级步骤
-**升级前注意备份数据**
-
-**数据升级**
-执行 `./iac-tool updateDB resource -m` 进行数据升级。
-如果是容器化部署执行: `docker-compose exec iac-portal ./iac-tool updateDB resource -m`
-
-
 ## v1.3.4 20221224
 ### Fixed
 - 修复删除历史漂移检测任务耗时过长的问题

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -512,3 +512,13 @@ SECRET_KEY=xxxx	# 变量值请根据环境进行设置
 ## v0.5.0 20210728
 全新 0.5.0 版本发布
 
+**Fixes**
+
+- 修复资源列表无法区分datasource和resource的问题
+
+#### 升级步骤
+**升级前注意备份数据**
+
+**数据升级**
+执行 `./iac-tool updateDB resource -m` 进行数据升级。
+如果是容器化部署执行: `docker-compose exec iac-portal ./iac-tool updateDB resource -m`

--- a/portal/models/resource.go
+++ b/portal/models/resource.go
@@ -28,6 +28,7 @@ type Resource struct {
 	Provider      string   `json:"provider" gorm:"not null"`
 	Module        string   `json:"module,omitempty" gorm:"not null;default:''"`
 	Address       string   `json:"address" gorm:"not null"`
+	Mode          string   `json:"mode" gorm:"not null"`
 	Type          string   `json:"type" gorm:"not null"`
 	Name          string   `json:"name" gorm:"not null"`
 	Index         string   `json:"index" gorm:"not null;default:''"`


### PR DESCRIPTION
fix:修复资源列表无法识别datasource、resource
（表iac_resource新增mode字段，识别资源类型。datasource资源的mode字段为data，resource资源的mode资源为managed）。
数据升级：
通过执行 `./iac-tool updateDB resource -m` 进行数据升级。
如果是容器化部署执行: `docker-compose exec iac-portal ./iac-tool updateDB resource -m`