### PR TITLE
fix: 环境费用统计接口报错 500

### DIFF
--- a/portal/services/env.go
+++ b/portal/services/env.go
@@ -683,7 +683,7 @@ func monthEnvCostList(tx *db.Session, id models.Id, isCurMonth bool) (map[string
 		query = query.Where(`iac_bill.cycle != DATE_FORMAT(CURDATE(), "%Y-%m")`)
 	}
 
-	query = query.Group("instance_id")
+	query = query.Group("instance_id, iac_resource.attrs")
 
 	var results []RawEnvCostDetail
 	if err := query.Find(&results); err != nil {


### PR DESCRIPTION
查询中包含一个非聚合的列 iac_resource.attrs，而这个列不依赖于 group by 子句中的列。这在当前的sql_mode设置中与"only_full_group_by"不兼容。