### PR TITLE
修改content类型为longblob

### DIFF
--- a/portal/models/task_log.go
+++ b/portal/models/task_log.go
@@ -11,7 +11,7 @@ type DBStorage struct {
 
 	Id        uint   `gorm:"primary_key" json:"-"`
 	Path      string `gorm:"NOT NULL;UNIQUE"`
-	Content   []byte `gorm:"type:MEDIUMBLOB"` // MEDIUMBLOB 支持最大长度约 16M
+	Content   []byte `gorm:"type:LONGBLOB"` // LONGBLOB 支持最大长度约 4G
 	CreatedAt Time   `gorm:"type:datetime"`
 }
 


### PR DESCRIPTION
tfstate.json文件超过16MB时，会导致无法存储到db_storage，导致没有资源列表，现改为longblob，大小增加为4G